### PR TITLE
fix: lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,9 +77,8 @@
   "bugs": "https://github.com/StackOneHQ/stackone-ai-node/issues",
   "homepage": "https://github.com/StackOneHQ/stackone-ai-node#readme",
   "lint-staged": {
-    "*.{js,ts,jsx,tsx}": [
-      "biome format --write",
-      "bun run typecheck"
+    "*": [
+      "biome check --write --no-errors-on-unmatched"
     ]
   }
 }


### PR DESCRIPTION

This pull request updates the `lint-staged` configuration in the `package.json` file to streamline the linting process and improve compatibility with various file types.

**Configuration changes:**

* Updated the `lint-staged` configuration to apply the `biome check` command to all file types (`*`) instead of specific JavaScript/TypeScript extensions. The `--no-errors-on-unmatched` flag was added to avoid errors for unmatched files. Removed the `bun run typecheck` step.