### PR TITLE
feat: add pkg.pr.new ci

### DIFF
--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  lint:
+  dry-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -1,0 +1,23 @@
+name: Dry Run Publish Package with pkg.pr.new
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: 🏡 Build package
+        run: bun run build
+
+      - name: 🚀 Dry Run Publish Package
+        run: bun x pkg-pr-new publish


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to perform a dry run of publishing a package using `pkg.pr.new`.

### New GitHub Actions Workflow:

* [`.github/workflows/dry-publish.yml`](diffhunk://#diff-27d1dd9519d5b80360746762b258dc32914c0bc5d3967fd771ee5939fd12b92aR1-R23): Added a workflow named "Dry Run Publish Package with pkg.pr.new" that triggers on `pull_request` and `push` events. It includes steps to check out the code, install dependencies using Bun, build the package, and perform a dry run of publishing with `pkg-pr-new`.