### PR TITLE
refactor: Replace enum with const object and enable erasableSyntaxOnly

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "openapi-types": "^12.1.3",
         "publint": "^0.3.12",
         "tsdown": "^0.12.8",
+        "type-fest": "^4.41.0",
         "unplugin-unused": "^0.5.1",
       },
       "peerDependencies": {
@@ -350,6 +351,8 @@
     "tsdown": ["tsdown@0.12.8", "", { "dependencies": { "ansis": "^4.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "debug": "^4.4.1", "diff": "^8.0.2", "empathic": "^1.1.0", "hookable": "^5.5.3", "rolldown": "1.0.0-beta.15", "rolldown-plugin-dts": "^0.13.11", "semver": "^7.7.2", "tinyexec": "^1.0.1", "tinyglobby": "^0.2.14", "unconfig": "^7.3.2" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-niHeVcFCNjvVZYVGTeoM4BF+/DWxP8pFH2tUs71sEKYdcKtJIbkSdEmtxByaRZeMgwVbVgPb8nv9i9okVwFLAA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "openapi-types": "^12.1.3",
     "publint": "^0.3.12",
     "tsdown": "^0.12.8",
+    "type-fest": "^4.41.0",
     "unplugin-unused": "^0.5.1"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * StackOne AI Node.js SDK
  */
 
-export { OpenAPILoader } from './openapi/loader';
+export * as OpenAPILoader from './openapi/loader';
 export { OpenAPIParser } from './openapi/parser';
 export { BaseTool, StackOneTool, Tools } from './tool';
 export { StackOneAPIError, StackOneError } from './utils/errors';

--- a/src/toolsets/openapi.ts
+++ b/src/toolsets/openapi.ts
@@ -1,4 +1,4 @@
-import { OpenAPILoader } from '../openapi/loader';
+import * as OpenAPILoader from '../openapi/loader';
 import { BaseTool } from '../tool';
 import type { ToolDefinition } from '../types';
 import { type BaseToolSetConfig, ToolSet, ToolSetConfigError, ToolSetLoadError } from './base';

--- a/src/toolsets/tests/openapi.spec.ts
+++ b/src/toolsets/tests/openapi.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import path from 'node:path';
-import { OpenAPILoader } from '../../openapi/loader';
+import * as OpenAPILoader from '../../openapi/loader';
 import { mockFetch } from '../../tests/utils/fetch-mock';
 import { ParameterLocation } from '../../types';
 import type { AuthenticationConfig } from '../base';

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import type { ValueOf } from 'type-fest';
 
 /**
  * Generic dictionary type for JSON-compatible objects
@@ -43,12 +44,14 @@ export type Experimental_PreExecuteFunction = (params: JsonDict) => Promise<Json
 /**
  * Valid locations for parameters in requests
  */
-export enum ParameterLocation {
-  HEADER = 'header',
-  QUERY = 'query',
-  PATH = 'path',
-  BODY = 'body',
-}
+export const ParameterLocation = {
+  HEADER: 'header',
+  QUERY: 'query',
+  PATH: 'path',
+  BODY: 'body',
+} as const satisfies Record<string, string>;
+
+export type ParameterLocation = ValueOf<typeof ParameterLocation>;
 
 /**
  * Configuration for executing a tool against an API endpoint

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
+    "erasableSyntaxOnly": true,
 
     /* Other */
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

This PR contains several refactoring improvements:

1. **Enable `erasableSyntaxOnly` in TypeScript config** - This is important because it allows TypeScript to strip type annotations without performing full type checking. With Node.js v24+ supporting native TypeScript execution via the `--strip-types` flag, this option ensures our codebase is compatible with running TypeScript files directly without compilation.

2. **Replace `ParameterLocation` enum with const object** - Converts the enum to a const object pattern which provides better tree-shaking, smaller bundle sizes, and avoids the runtime overhead of TypeScript enums while maintaining type safety.

3. **Remove namespace usage** - Modernizes the codebase by removing legacy namespace patterns in favor of standard ES modules.

## Changes
- Added `erasableSyntaxOnly: true` to tsconfig.json for Node.js v24+ compatibility
- Converted `ParameterLocation` enum to const object with type inference
- Removed namespace declarations across the codebase
- Updated all references to use the new const object pattern

## Benefits
- Enables running TypeScript directly in Node.js v24+ without compilation
- Reduces bundle size by eliminating enum runtime code
- Improves tree-shaking capabilities
- Modernizes codebase patterns