### PR TITLE
chore: update model references to gpt-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const toolset = new StackOneToolSet();
 const tools = toolset.getTools("hris_*", "<stackone-account-id>").toOpenAI();
 
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5",
   messages: [
     {
       role: "system",
@@ -72,7 +72,7 @@ const toolset = new StackOneToolSet();
 
 const aiSdkTools = toolset.getTools("hris_*").toAISDK();
 await generateText({
-  model: openai("gpt-4o"),
+  model: openai("gpt-5"),
   tools: aiSdkTools,
   maxSteps: 3,
 });

--- a/examples/ai-sdk-integration.ts
+++ b/examples/ai-sdk-integration.ts
@@ -21,7 +21,7 @@ const aiSdkIntegration = async (): Promise<void> => {
 
   // Use max steps to automatically call the tool if it's needed
   const { text } = await generateText({
-    model: openai('gpt-4.1-mini'),
+    model: openai('gpt-5'),
     tools: aiSdkTools,
     prompt: 'Get all details about employee with id: c28xIQaWQ6MzM5MzczMDA2NzMzMzkwNzIwNA',
     maxSteps: 3,

--- a/examples/human-in-the-loop.ts
+++ b/examples/human-in-the-loop.ts
@@ -39,7 +39,7 @@ const humanInTheLoopExample = async (): Promise<void> => {
 
   // Use the metadata for AI planning/generation
   const { toolCalls } = await generateText({
-    model: openai('gpt-4o'),
+    model: openai('gpt-5'),
     tools: tool,
     prompt:
       'Create a new employee in Workday, params: Full name: John Doe, personal email: john.doe@example.com, department: Engineering, start date: 2025-01-01, hire date: 2025-01-01',

--- a/examples/openai-integration.ts
+++ b/examples/openai-integration.ts
@@ -21,7 +21,7 @@ const openaiIntegration = async (): Promise<void> => {
 
   // Create a chat completion with tool calls
   const response = await openai.chat.completions.create({
-    model: 'gpt-4o-mini',
+    model: 'gpt-5',
     messages: [
       {
         role: 'system',

--- a/examples/planning.ts
+++ b/examples/planning.ts
@@ -29,7 +29,7 @@ export const planningModule = async (): Promise<void> => {
    * or use as part of a larger agent (using AI SDK by Vercel)
    */
   await generateText({
-    model: openai('gpt-4o'),
+    model: openai('gpt-5'),
     prompt: 'You are a workplace agent, onboard the latest hires to our systems',
     tools: onboardWorkflow.toAISDK(),
     maxSteps: 3,


### PR DESCRIPTION
## Summary
- Updated all model references from various GPT versions to gpt-5
- Changes made across examples and README documentation

## Changes
- Updated model in README.md examples from gpt-4o to gpt-5
- Updated model in examples/ai-sdk-integration.ts from gpt-4.1-mini to gpt-5
- Updated model in examples/human-in-the-loop.ts from gpt-4o to gpt-5
- Updated model in examples/openai-integration.ts from gpt-4o-mini to gpt-5
- Updated model in examples/planning.ts from gpt-4o to gpt-5

## Test Plan
- [ ] Verify examples still compile successfully
- [ ] Update dependencies if new model requires different API versions
- [ ] Test that model references are correctly passed to OpenAI SDK
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated all model references in documentation and example files to use gpt-5 instead of previous GPT versions. This ensures consistency and prepares examples for the latest model.

- **Refactors**
 - Changed model names in README and all example scripts to gpt-5.

<!-- End of auto-generated description by cubic. -->

