### PR TITLE
chore: isolated install

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,6 @@
 [test]
 preload = ["./bun.test.setup.ts"]
+
+[install]
+linker = "isolated"
+


### PR DESCRIPTION
https://bun.com/docs/install/isolated

pnpm style install. better for deps management
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable Bun’s isolated installer (pnpm-style) by setting install.linker = "isolated" in bunfig.toml. This gives non-hoisted node_modules for better dependency isolation and more reproducible installs.

- **Migration**
  - Run bun install after pulling.
  - If you hit conflicts, remove node_modules and reinstall.

<!-- End of auto-generated description by cubic. -->

