### PR TITLE
ci: replace bun install with bun ci for reproducible builds

### DIFF
--- a/.github/workflows/check-oas-updates.yml
+++ b/.github/workflows/check-oas-updates.yml
@@ -25,7 +25,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Fetch latest OAS specs
         run: bun run fetch:specs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install Node dependencies
-        run: bun install
+        run: bun ci
 
       - name: Build documentation
         run: bun docs:build

--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: 🏡 Build package
         run: bun run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Run Lint
         run: bun lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       # TODO change this to bun test
       - name: Run tests


### PR DESCRIPTION
## Summary

Replace all instances of `bun install` with `bun ci` across GitHub Actions workflow files to ensure reproducible and deterministic builds in CI environments.

## What Changed

- ✅ Updated `.github/workflows/check-oas-updates.yml` to use `bun ci`
- ✅ Updated `.github/workflows/docs.yml` to use `bun ci`  
- ✅ Updated `.github/workflows/dry-publish.yml` to use `bun ci`
- ✅ Updated `.github/workflows/lint.yml` to use `bun ci`
- ✅ Updated `.github/workflows/test.yml` to use `bun ci`

## Why

Using `bun ci` instead of `bun install` in CI environments provides several critical benefits:

### 🔒 **Deterministic Builds**
- Ensures exact dependency versions match `bun.lockb`
- Prevents unexpected dependency version drift during CI runs
- Guarantees consistent builds across all CI environments

### ⚡ **Fail-Fast Behavior** 
- Immediately fails if lockfile is outdated or inconsistent with `package.json`
- Catches dependency issues early in the CI pipeline
- Prevents silent dependency mismatches that could lead to runtime issues

### 🎯 **Best Practices Compliance**
- Follows recommended practices for package managers in CI/CD
- Aligns with industry standards for reproducible builds
- Improves overall CI reliability and consistency

### 🛡️ **Build Reliability**
- Reduces risk of "works on my machine" issues
- Ensures production builds use the same exact dependencies as development
- Provides confidence in deployment consistency

## Testing

- ✅ All existing workflow files have been updated consistently
- ✅ No breaking changes to workflow functionality
- ✅ Changes are backwards compatible with existing `bun.lockb`

This change improves our CI pipeline's reliability while maintaining all existing functionality. The next time these workflows run, they will benefit from more deterministic and reproducible dependency installation.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replace bun install with bun ci in all GitHub Actions workflows to enforce lockfile-only installs and reproducible builds. CI now fails fast on lockfile drift and uses exact versions from bun.lockb.

- **Refactors**
  - Updated check-oas-updates.yml, docs.yml, dry-publish.yml, lint.yml, and test.yml to run bun ci instead of bun install.

<!-- End of auto-generated description by cubic. -->

