### PR TITLE
chore: run rebuild script as a prepack on publish

### DIFF
--- a/.github/workflows/dry-publish.yml
+++ b/.github/workflows/dry-publish.yml
@@ -16,8 +16,5 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: 🏡 Build package
-        run: bun run build
-
       - name: 🚀 Dry Run Publish Package
         run: bun x pkg-pr-new publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,5 @@ jobs:
       - name: 💫 Install dependencies
         run: bun i
 
-      - name: 🏡 Build package
-        run: bun run build
-
       - name: 🚀 Publish package
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky && bun run fetch:specs",
     "build": "bun -b tsdown",
     "rebuild": "bun run fetch:specs && bun run build",
-    "prepublishOnly": "bun run rebuild",
+    "prepack": "bun run rebuild",
     "test:unit": "bun test src",
     "test:examples": "bun test examples",
     "test:scripts": "bun test scripts",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Run rebuild during prepack so every publish includes a fresh build, and remove manual build steps from CI to avoid duplicates. This makes dry-run and real releases consistent.

- **Refactors**
  - package.json: switch from prepublishOnly to prepack to run bun run rebuild (fetch specs + build) on pack/publish.
  - Workflows: remove "Build package" step from dry-publish.yml and release.yml; npm publish and pkg-pr-new now rely on prepack.

<!-- End of auto-generated description by cubic. -->

