### PR TITLE
fix: remove unnecessary type assertion in BaseTool

### DIFF
--- a/src/tool.ts
+++ b/src/tool.ts
@@ -136,7 +136,7 @@ export class BaseTool {
           },
         }),
       },
-    } as ToolSet;
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

This PR removes an unnecessary type assertion (`as ToolSet`) in the `BaseTool.toToolSet()` method. The return type is already properly inferred from the method signature, making the explicit type assertion redundant.

## What Changed

- Removed `as ToolSet` type assertion from the return statement in `src/tool.ts`
- The method return type is already defined as `ToolSet` in the method signature, ensuring type safety without the manual assertion

## Why

Type assertions should be avoided when TypeScript's type inference can correctly determine the type. In this case:

1. The method signature already declares the return type as `ToolSet`
2. The returned object structure matches the `ToolSet` interface exactly
3. The type assertion was redundant and could mask potential type mismatches

Removing unnecessary type assertions:
- Improves code clarity
- Reduces maintenance burden
- Allows TypeScript's type checker to catch actual type mismatches
- Follows TypeScript best practices

## Testing

- Existing unit tests continue to pass
- Type checking passes without the assertion
- No behavioral changes - this is purely a type-level improvement

To verify:
```bash
bun run typecheck
bun run test
```

## Related Issues

None - this is a code quality improvement discovered during development.