### PR TITLE
refactor: extract DEFAULT_HYBRID_ALPHA to constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,14 @@ export const SPECS = [
   'iam',
   'lms',
 ];
+
+/**
+ * Default weight for BM25 in hybrid BM25 + TF-IDF search.
+ *
+ * - alpha=0.2 means: 20% BM25 + 80% TF-IDF
+ * - This value was optimized through validation testing
+ * - Provides 10.8% improvement in tool discovery accuracy
+ * - Lower values favor BM25 scoring (better keyword matching)
+ * - Higher values favor TF-IDF scoring (better semantic matching)
+ */
+export const DEFAULT_HYBRID_ALPHA = 0.2;

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,5 +1,6 @@
 import * as orama from '@orama/orama';
 import type { ChatCompletionTool } from 'openai/resources/chat/completions';
+import { DEFAULT_HYBRID_ALPHA } from './constants';
 import { RequestBuilder } from './modules/requestBuilder';
 import type {
   ExecuteConfig,
@@ -379,9 +380,9 @@ export class Tools implements Iterable<BaseTool> {
   /**
    * Return meta tools for tool discovery and execution
    * @beta This feature is in beta and may change in future versions
-   * @param hybridAlpha - Weight for BM25 in hybrid search (0-1, default 0.2). Lower values favor BM25 scoring.
+   * @param hybridAlpha - Weight for BM25 in hybrid search (0-1). If not provided, uses DEFAULT_HYBRID_ALPHA (0.2).
    */
-  async metaTools(hybridAlpha = 0.2): Promise<Tools> {
+  async metaTools(hybridAlpha = DEFAULT_HYBRID_ALPHA): Promise<Tools> {
     const oramaDb = await initializeOramaDb(this.tools);
     const tfidfIndex = initializeTfidfIndex(this.tools);
     const baseTools = [
@@ -520,7 +521,7 @@ export function metaSearchTools(
   oramaDb: OramaDb,
   tfidfIndex: TfidfIndex,
   allTools: BaseTool[],
-  hybridAlpha = 0.2
+  hybridAlpha = DEFAULT_HYBRID_ALPHA
 ): BaseTool {
   const name = 'meta_search_tools' as const;
   const description =


### PR DESCRIPTION
## Summary

Extract the magic number `0.2` to a named constant `DEFAULT_HYBRID_ALPHA` in `src/constants.ts` for better code maintainability and documentation.

## Motivation

The hybrid search alpha value (0.2) is currently used as a magic number in multiple locations:
- `metaTools()` default parameter
- `metaSearchTools()` default parameter

This makes it:
- ❌ Hard to understand why 0.2 is chosen
- ❌ Easy to accidentally use different values
- ❌ Difficult to update if we optimize the value

## Changes

1. **Added constant** (`src/constants.ts`):
   ```typescript
   export const DEFAULT_HYBRID_ALPHA = 0.2;
   ```
   - Includes comprehensive documentation
   - Explains the 20% BM25 + 80% TF-IDF split
   - Documents the 10.8% accuracy improvement
   - Explains when to use different values

2. **Updated usage** (`src/tool.ts`):
   - `metaTools(hybridAlpha = DEFAULT_HYBRID_ALPHA)`
   - `metaSearchTools(..., hybridAlpha = DEFAULT_HYBRID_ALPHA)`

## Benefits

- ✅ Single source of truth for the default value
- ✅ Clear documentation of why 0.2 was chosen
- ✅ Easier to update if we optimize the value further
- ✅ More discoverable for developers

## Testing

```bash
bun test src/tests/meta-tools.spec.ts
```

**Results:**
- ✅ 23 tests pass
- ✅ All assertions pass
- ✅ No behavior changes

## Feature Parity

Matches constant extraction done in Python SDK (stackone-ai-python#37).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the default hybrid search alpha by extracting the 0.2 value into a shared constant, improving consistency across metaTools and metaSearchTools and clarifying the rationale.

- **Refactors**
  - Introduced DEFAULT_HYBRID_ALPHA = 0.2 in src/constants.ts with docs on BM25/TF‑IDF weighting and accuracy impact; mirrors Python SDK.
  - Updated metaTools() and metaSearchTools() to use the constant.
  - No behavior changes; existing tests pass.

<sup>Written for commit d9cb5710c2b20186600685721916efbe7fb7dc34. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

