### PR TITLE
fix: Pinning GitHub actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@6337623ebba10cf8c8214b507993f8062fd4ccfb # v1.0.22
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin the Claude Code GitHub Action in .github/workflows/claude.yml to commit 6337623 (v1.0.22) instead of the beta tag to make CI runs deterministic and comply with the org-wide pinning policy. Addresses ENG-11298.

<sup>Written for commit 16818acfccd0c53eb21666d9318cdf2ce9b90dbb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

