### PR TITLE
fix: remove an ambiguous keyword(saas) from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   "keywords": [
     "stackone",
     "ai",
-    "saas",
     "tools",
     "agents",
     "ai sdk",


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the ambiguous "saas" keyword from package.json to avoid misleading categorization.

<sup>Written for commit ed71109a4856d36f05a7f809d551622b205ccecd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





