### PR TITLE
docs: update GPT model references to gpt-5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const tools = await toolset.fetchTools({
 });
 
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5.1",
   messages: [
     {
       role: "system",
@@ -107,7 +107,7 @@ const tools = await toolset.fetchTools({
 });
 
 await generateText({
-  model: openai("gpt-4o"),
+  model: openai("gpt-5.1"),
   tools: await tools.toAISDK(),
   maxSteps: 3,
 });
@@ -350,7 +350,7 @@ import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
 const { text } = await generateText({
-  model: openai("gpt-4o-mini"),
+  model: openai("gpt-5.1"),
   tools: aiSdkTools,
   prompt: "Find tools for managing employees and create a time off request",
   maxSteps: 3, // Allow multiple tool calls

--- a/examples/ai-sdk-integration.ts
+++ b/examples/ai-sdk-integration.ts
@@ -32,7 +32,7 @@ const aiSdkIntegration = async (): Promise<void> => {
 
   // The AI SDK will automatically call the tool if needed
   const { text } = await generateText({
-    model: openai('gpt-4o'),
+    model: openai('gpt-5.1'),
     tools: aiSdkTools,
     prompt: 'Get all details about employee with id: c28xIQaWQ6MzM5MzczMDA2NzMzMzkwNzIwNA',
     stopWhen: stepCountIs(3),

--- a/examples/human-in-the-loop.ts
+++ b/examples/human-in-the-loop.ts
@@ -50,7 +50,7 @@ const humanInTheLoopExample = async (): Promise<void> => {
 
   // Use the metadata for AI planning/generation
   const { toolCalls } = await generateText({
-    model: openai('gpt-4o'),
+    model: openai('gpt-5.1'),
     tools: tool,
     prompt:
       'Create a new employee in Workday, params: Full name: John Doe, personal email: john.doe@example.com, department: Engineering, start date: 2025-01-01, hire date: 2025-01-01',

--- a/examples/meta-tools.ts
+++ b/examples/meta-tools.ts
@@ -39,7 +39,7 @@ const metaToolsWithAISDK = async (): Promise<void> => {
 
   // Use meta tools to dynamically find and execute relevant tools
   const { text, toolCalls } = await generateText({
-    model: openai('gpt-4o-mini'),
+    model: openai('gpt-5.1'),
     tools: aiSdkMetaTools,
     prompt: `I need to create a time off request for an employee.
     First, find the right tool for this task, then use it to create a time off request
@@ -79,7 +79,7 @@ const metaToolsWithOpenAI = async (): Promise<void> => {
 
   // Create an HR assistant that can discover and use tools dynamically
   const response = await openaiClient.chat.completions.create({
-    model: 'gpt-4o-mini',
+    model: 'gpt-5.1',
     messages: [
       {
         role: 'system',

--- a/examples/openai-integration.ts
+++ b/examples/openai-integration.ts
@@ -32,7 +32,7 @@ const openaiIntegration = async (): Promise<void> => {
 
   // Create a chat completion with tool calls
   const response = await openai.chat.completions.create({
-    model: 'gpt-4o',
+    model: 'gpt-5.1',
     messages: [
       {
         role: 'system',


### PR DESCRIPTION
## Summary
- Update all OpenAI model references from `gpt-4o` and `gpt-4o-mini` to `gpt-5.1`
- Updated files: README.md, examples/ai-sdk-integration.ts, examples/human-in-the-loop.ts, examples/meta-tools.ts, examples/openai-integration.ts

## Test plan
- [ ] Verify code examples in README.md are accurate
- [ ] Review example files for consistency

Fixes #158

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated all OpenAI model references from gpt-4o and gpt-4o-mini to gpt-5.1 in the README and example files. Keeps docs and examples aligned with the current default model and resolves #158.

<sup>Written for commit f2c622fdc6c578cf29bb5d33a655bd2b27e988d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

