### PR TITLE
chore: use biome format -> biome check for lefthook

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -6,5 +6,5 @@ pre-commit:
       run: pnpm run typecheck
     format:
       glob: "*.{ts,tsx,js,jsx,mts,cts,json,jsonc,yaml,yml,md}"
-      run: pnpm biome format --no-errors-on-unmatched --write {staged_files}
+      run: pnpm biome check --no-errors-on-unmatched --write {staged_files}
       stage_fixed: true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch pre-commit formatting from biome format to biome check. This validates and auto-fixes staged files while ignoring unmatched files.

<sup>Written for commit b5a29ad150f7ddb3c884eacfa3d1dd3f5e411424. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

