### PR TITLE
fix(package.json): add engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
       "./package.json": "./package.json"
     }
   },
+  "engines": {
+    "node": ">=20.19.6"
+  },
   "devEngines": {
     "runtime": [
       {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the Node engine in package.json to >=20.19.6 to avoid issues on older Node and keep environments consistent. Package managers will warn or block installs on unsupported versions.

- **Migration**
  - Upgrade local Node to 20.19.6+.
  - Update CI/hosting to use Node 20.19.6+.

<sup>Written for commit 82b0d58978b9069be70e7cf09f56725ced064c61. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

