### PR TITLE
chore: remove env_exampele

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,2 +1,0 @@
-STACKONE_API_KEY=your_stackone_api_key
-OPENAI_API_KEY=your_openai_api_key


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the obsolete .env_example file to avoid confusion around environment setup and placeholder API keys. No runtime or build impact.

<sup>Written for commit 63739d3cb0038a458034bd4d0cea85aff2c0287e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

