### PR TITLE
fix(rpc): send x-account-id as HTTP header in RPC requests

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -233,6 +233,7 @@ export const handlers = [
 	// ============================================================
 	http.post('https://api.stackone.com/actions/rpc', async ({ request }) => {
 		const authHeader = request.headers.get('Authorization');
+		const accountIdHeader = request.headers.get('x-account-id');
 
 		// Check for authentication
 		if (!authHeader || !authHeader.startsWith('Basic ')) {
@@ -256,6 +257,16 @@ export const handlers = [
 				{ error: 'Bad Request', message: 'Action is required' },
 				{ status: 400 },
 			);
+		}
+
+		// Test action to verify x-account-id is sent as HTTP header
+		if (body.action === 'test_account_id_header') {
+			return HttpResponse.json({
+				data: {
+					httpHeader: accountIdHeader,
+					bodyHeader: body.headers?.['x-account-id'],
+				},
+			});
 		}
 
 		// Return mock response based on action

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "catalog:prod",
 		"@orama/orama": "catalog:prod",
+		"defu": "catalog:prod",
 		"json-schema": "catalog:prod",
 		"zod": "catalog:dev"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   dev:
+    '@ai-sdk/openai':
+      specifier: ^2.0.80
+      version: 2.0.80
     '@ai-sdk/provider-utils':
       specifier: ^3.0.18
       version: 3.0.18
@@ -80,6 +83,9 @@ catalogs:
     '@orama/orama':
       specifier: ^3.1.11
       version: 3.1.16
+    defu:
+      specifier: ^6.1.4
+      version: 6.1.4
     json-schema:
       specifier: ^0.4.0
       version: 0.4.0
@@ -93,6 +99,9 @@ importers:
       '@orama/orama':
         specifier: catalog:prod
         version: 3.1.16
+      defu:
+        specifier: catalog:prod
+        version: 6.1.4
       json-schema:
         specifier: catalog:prod
         version: 0.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalogs:
   prod:
     '@modelcontextprotocol/sdk': ^1.24.3
     '@orama/orama': ^3.1.11
+    defu: ^6.1.4
     json-schema: ^0.4.0
 
 enablePrePostScripts: true

--- a/src/rpc-client.test.ts
+++ b/src/rpc-client.test.ts
@@ -1,4 +1,5 @@
 import { RpcClient } from './rpc-client';
+import { stackOneHeadersSchema } from './schemas/headers';
 import { StackOneAPIError } from './utils/errors';
 
 test('should successfully execute an RPC action', async () => {
@@ -28,7 +29,7 @@ test('should send correct payload structure', async () => {
 	const response = await client.actions.rpcAction({
 		action: 'custom_action',
 		body: { key: 'value' },
-		headers: { 'x-custom': 'header' },
+		headers: stackOneHeadersSchema.parse({ 'x-custom': 'header' }),
 		path: { id: '123' },
 		query: { filter: 'active' },
 	});
@@ -101,4 +102,21 @@ test('should work with only action parameter', async () => {
 
 	// Response has data field (server returns { data: { action, received } })
 	expect(response).toHaveProperty('data');
+});
+
+test('should send x-account-id as HTTP header', async () => {
+	const client = new RpcClient({
+		security: { username: 'test-api-key' },
+	});
+
+	const response = await client.actions.rpcAction({
+		action: 'test_account_id_header',
+		headers: stackOneHeadersSchema.parse({ 'x-account-id': 'test-account-123' }),
+	});
+
+	// Verify x-account-id is sent both as HTTP header and in request body
+	expect(response.data).toMatchObject({
+		httpHeader: 'test-account-123',
+		bodyHeader: 'test-account-123',
+	});
 });

--- a/src/schemas/headers.ts
+++ b/src/schemas/headers.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod/mini';
+
+/**
+ * Known StackOne API header keys that are forwarded as HTTP headers
+ */
+export const STACKONE_HEADER_KEYS = ['x-account-id'] as const;
+
+/**
+ * Zod schema for StackOne API headers (branded)
+ * These headers are forwarded as HTTP headers in API requests
+ */
+export const stackOneHeadersSchema = z.record(z.string(), z.string()).brand<'StackOneHeaders'>();
+
+/**
+ * Branded type for StackOne API headers
+ */
+export type StackOneHeaders = z.infer<typeof stackOneHeadersSchema>;

--- a/src/schemas/rpc.ts
+++ b/src/schemas/rpc.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/mini';
+import { stackOneHeadersSchema } from './headers';
 
 /**
  * Zod schema for RPC action request validation
@@ -7,7 +8,7 @@ import { z } from 'zod/mini';
 export const rpcActionRequestSchema = z.object({
 	action: z.string(),
 	body: z.optional(z.record(z.string(), z.unknown())),
-	headers: z.optional(z.record(z.string(), z.unknown())),
+	headers: z.optional(stackOneHeadersSchema),
 	path: z.optional(z.record(z.string(), z.unknown())),
 	query: z.optional(z.record(z.string(), z.unknown())),
 });

--- a/src/utils/headers.test.ts
+++ b/src/utils/headers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { normaliseHeaders } from './headers';
+
+describe('normaliseHeaders', () => {
+	it('returns empty object for undefined input', () => {
+		expect(normaliseHeaders(undefined)).toEqual({});
+	});
+
+	it('returns empty object for empty input', () => {
+		expect(normaliseHeaders({})).toEqual({});
+	});
+
+	it('preserves string values', () => {
+		expect(normaliseHeaders({ foo: 'bar', baz: 'qux' })).toEqual({
+			foo: 'bar',
+			baz: 'qux',
+		});
+	});
+
+	it('converts numbers to strings', () => {
+		expect(normaliseHeaders({ port: 8080, timeout: 30 })).toEqual({
+			port: '8080',
+			timeout: '30',
+		});
+	});
+
+	it('converts booleans to strings', () => {
+		expect(normaliseHeaders({ enabled: true, debug: false })).toEqual({
+			enabled: 'true',
+			debug: 'false',
+		});
+	});
+
+	it('serialises objects to JSON', () => {
+		expect(normaliseHeaders({ config: { key: 'value' } })).toEqual({
+			config: '{"key":"value"}',
+		});
+	});
+
+	it('serialises arrays to JSON', () => {
+		expect(normaliseHeaders({ tags: ['foo', 'bar'] })).toEqual({
+			tags: '["foo","bar"]',
+		});
+	});
+
+	it('skips undefined values', () => {
+		expect(normaliseHeaders({ foo: 'bar', baz: undefined })).toEqual({
+			foo: 'bar',
+		});
+	});
+
+	it('skips null values', () => {
+		expect(normaliseHeaders({ foo: 'bar', baz: null })).toEqual({
+			foo: 'bar',
+		});
+	});
+
+	it('handles mixed value types', () => {
+		expect(
+			normaliseHeaders({
+				string: 'text',
+				number: 42,
+				boolean: true,
+				object: { nested: 'value' },
+				array: [1, 2, 3],
+				nullValue: null,
+				undefinedValue: undefined,
+			}),
+		).toEqual({
+			string: 'text',
+			number: '42',
+			boolean: 'true',
+			object: '{"nested":"value"}',
+			array: '[1,2,3]',
+		});
+	});
+});

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,30 @@
+import { type StackOneHeaders, stackOneHeadersSchema } from '../schemas/headers';
+import type { JsonDict } from '../types';
+
+/**
+ * Normalises header values from JsonDict to StackOneHeaders (branded type)
+ * Converts numbers and booleans to strings, and serialises objects to JSON
+ *
+ * @param headers - Headers object with unknown value types
+ * @returns Normalised headers with string values only (branded type)
+ */
+export function normaliseHeaders(headers: JsonDict | undefined): StackOneHeaders {
+	if (!headers) return stackOneHeadersSchema.parse({});
+	const result: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		switch (true) {
+			case value == null:
+				continue;
+			case typeof value === 'string':
+				result[key] = value;
+				break;
+			case typeof value === 'number' || typeof value === 'boolean':
+				result[key] = String(value);
+				break;
+			default:
+				result[key] = JSON.stringify(value);
+				break;
+		}
+	}
+	return stackOneHeadersSchema.parse(result);
+}


### PR DESCRIPTION
## Summary

- Fixed RPC client to send `x-account-id` as an actual HTTP header, not just in the request body
- The StackOne API requires `x-account-id` as an HTTP header for authentication/authorisation
- Implemented branded types using Zod for type-safe header handling
- Added `defu` library for clean header merging
- Created utility function with comprehensive tests

## Problem

When executing tools via the RPC endpoint (`/actions/rpc`), the API returned:
```
400 Bad Request: Missing x-account-id header or query parameter in request
```

The `x-account-id` was being sent in the request body's `headers` field:
```json
{
  "action": "...",
  "headers": { "x-account-id": "..." },
  ...
}
```

But the API expects it as an actual HTTP header on the request.

## Solution

### Architecture Changes

1. **Created `src/schemas/headers.ts`**:
   - Defined `STACKONE_HEADER_KEYS` constant for known headers to forward
   - Created `stackOneHeadersSchema` with Zod branding for type safety
   - Exported `StackOneHeaders` branded type

2. **Created `src/utils/headers.ts`**:
   - Extracted `normaliseHeaders()` utility function
   - Converts mixed types (number, boolean, object) to strings
   - Added 10 comprehensive unit tests

3. **Updated `src/toolsets/base.ts`**:
   - Use `defu` for clean header merging
   - Parse headers through schema to get branded type
   - Ensures type safety throughout the flow

4. **Updated `src/rpc-client.ts`**:
   - Forward all StackOne-specific headers as HTTP headers
   - Iterate over `STACKONE_HEADER_KEYS` constant
   - Preserve headers in body for backwards compatibility

### Key Features

- **Type Safety**: Zod branded types ensure headers are validated
- **Extensible**: Easy to add more headers to `STACKONE_HEADER_KEYS`
- **Clean Code**: Used `defu` for merging, extracted utility functions
- **Well Tested**: Added 10 new tests, all 306 tests pass

## Test plan

- [x] Added unit test `should send x-account-id as HTTP header` to verify the fix
- [x] Added 10 unit tests for `normaliseHeaders()` utility function
- [x] All existing tests pass (306 tests total, 27 test files)
- [x] Updated MSW mock handler to capture and return both HTTP header and body header values for verification
- [x] Lint passes with no errors