### PR TITLE
docs(workflow): remove biome references from development workflow skill

### DIFF
--- a/.claude/skills/development-workflow/SKILL.md
+++ b/.claude/skills/development-workflow/SKILL.md
@@ -24,8 +24,8 @@ This skill provides all commands and best practices for building, developing, an
 
 ## Code Quality
 
-- `pnpm lint` - Run Biome linter
-- `pnpm format` - Format code with Biome
+- `pnpm lint` - Run linter (oxfmt, oxlint, knip)
+- `pnpm format` - Format code (oxfmt, oxlint, knip)
 - `pnpm typecheck` - Type check with tsgo
 - `pnpm lint:fix` - Auto-fix linting issues
 


### PR DESCRIPTION
## Summary

- Remove outdated Biome references from development workflow skill documentation
- Update lint and format command descriptions to reflect current tools (oxfmt, oxlint, knip)

## Test Plan

- Verify that the documentation accurately describes the current linting and formatting tools
- Confirm no other references to Biome exist in the codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated Biome references in the development workflow skill and updated lint/format command descriptions to reflect current tools (oxfmt, oxlint, knip). This keeps the docs accurate and aligned with our current toolchain.

<sup>Written for commit aaf0721ef84f85b1b029a2d604cab56bf903a26c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

