### PR TITLE
test: simplify mcp test server type

### DIFF
--- a/mocks/mcp-server.ts
+++ b/mocks/mcp-server.ts
@@ -134,7 +134,7 @@ export const accountMcpTools = {
 				required: ['id'],
 			},
 		},
-	] as const satisfies McpToolDefinition[],
+	],
 	acc2: [
 		{
 			name: 'acc2_tool_1',
@@ -153,7 +153,7 @@ export const accountMcpTools = {
 				required: ['id'],
 			},
 		},
-	] as const satisfies McpToolDefinition[],
+	],
 	acc3: [
 		{
 			name: 'acc3_tool_1',
@@ -163,7 +163,7 @@ export const accountMcpTools = {
 				properties: { fields: { type: 'string' } },
 			},
 		},
-	] as const satisfies McpToolDefinition[],
+	],
 	'test-account': [
 		{
 			name: 'dummy_action',
@@ -180,8 +180,8 @@ export const accountMcpTools = {
 				additionalProperties: false,
 			},
 		},
-	] as const satisfies McpToolDefinition[],
-} as const;
+	],
+} as const satisfies Record<string, McpToolDefinition[]>;
 
 export const mixedProviderTools = [
 	{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified MCP test server type definitions by typing accountMcpTools at the object level as Record<string, McpToolDefinition[]> and removing per-array type assertions. No runtime behavior change.

<sup>Written for commit a2bc073324507c18344bae2c3fab3aadadbd711a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

