### PR TITLE
fix(lefthook): use pnpm

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -3,14 +3,14 @@ pre-commit:
   jobs:
     - name: oxlint
       glob: '*.{ts,tsx,js,jsx,mts,cts}'
-      run: bun oxlint --max-warnings=0 --type-aware --type-check --fix {staged_files}
+      run: pnpm oxlint --max-warnings=0 --type-aware --type-check --fix {staged_files}
       stage_fixed: true
     - name: oxfmt
       glob: '*'
-      run: bun oxfmt --no-error-on-unmatched-pattern {staged_files}
+      run: pnpm oxfmt --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
 
-push:
+pre-push:
   jobs:
     - name: knip
       run: pnpm run lint:knip


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched lefthook to run oxlint/oxfmt via pnpm instead of bun and renamed the push hook to pre-push. This aligns hook tooling with our package manager and ensures the correct pre-push checks run.

<sup>Written for commit a1605c609ef36cdb019a2434746bf6e5c1e5382a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

