### PR TITLE
refactor!: remove unused experimental features and internal exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@
  * StackOne AI Node.js SDK
  */
 
-export { DEFAULT_BASE_URL, DEFAULT_HYBRID_ALPHA } from './consts';
 export { BaseTool, StackOneTool, Tools } from './tool';
 export { createFeedbackTool } from './feedback';
 export { StackOneAPIError, StackOneError } from './utils/errors';
@@ -22,9 +21,6 @@ export type {
 	AISDKToolResult,
 	ExecuteConfig,
 	ExecuteOptions,
-	Experimental_PreExecuteFunction,
-	Experimental_SchemaOverride,
-	Experimental_ToolCreationOptions,
 	JsonDict,
 	ParameterLocation,
 	ToolDefinition,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,22 +28,6 @@ export type JsonSchemaProperties = Record<string, JSONSchema7Definition>;
 type JsonSchemaType = JSONSchema7['type'];
 
 /**
- * EXPERIMENTAL: Function to override the tool schema at creation time
- * Takes the original tool parameters and returns a new schema
- * @param originalSchema - The original tool parameters schema from OpenAPI
- * @returns New schema definition for the tool
- */
-export type Experimental_SchemaOverride = (originalSchema: ToolParameters) => ToolParameters;
-
-/**
- * EXPERIMENTAL: Function to preprocess parameters before tool execution
- * Transforms parameters from override schema format back to original API format
- * @param params - The input parameters in override schema format
- * @returns Parameters in original API format
- */
-export type Experimental_PreExecuteFunction = (params: JsonDict) => Promise<JsonDict> | JsonDict;
-
-/**
  * Valid locations for parameters in requests
  */
 export const ParameterLocation = {
@@ -98,23 +82,6 @@ export interface LocalExecuteConfig {
  * Discriminated union lets call sites branch on execution style without relying on nullable fields.
  */
 export type ExecuteConfig = HttpExecuteConfig | RpcExecuteConfig | LocalExecuteConfig;
-
-/**
- * EXPERIMENTAL: Options for creating tools with schema overrides and preExecute functions
- */
-export interface Experimental_ToolCreationOptions {
-	/**
-	 * EXPERIMENTAL: Function to override the tool schema at creation time
-	 * Takes the original schema and returns a new schema for the tool
-	 */
-	experimental_schemaOverride?: Experimental_SchemaOverride;
-
-	/**
-	 * EXPERIMENTAL: Function to preprocess parameters before execution
-	 * Transforms parameters from override schema format back to original API format
-	 */
-	experimental_preExecute?: Experimental_PreExecuteFunction;
-}
 
 /**
  * Options for executing a tool


### PR DESCRIPTION
## Summary

Remove unused experimental features and internal implementation details from the public API.

## What Changed

**Removed exports:**
- `DEFAULT_BASE_URL` - Internal constant (users override via `baseUrl` option)
- `DEFAULT_HYBRID_ALPHA` - Internal constant for meta tools search
- `Experimental_SchemaOverride` - Unused type
- `Experimental_PreExecuteFunction` - Unused type
- `Experimental_ToolCreationOptions` - Unused interface

**Removed implementation:**
- `BaseTool.experimental_preExecute` property and constructor parameter
- `Tools.getTool()` options parameter and associated schema override logic

## Why

These experimental features were implemented but never documented, tested, or used in examples. Removing them:
- Simplifies the public API surface
- Removes dead code
- Makes the SDK easier to maintain

## Breaking Change

This is a breaking change for any users who were importing these types/constants, though usage is expected to be minimal given they were undocumented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed undocumented experimental hooks and internal constants from the public API to simplify the SDK and remove dead code. This is a breaking change for anyone importing those exports or using pre-execute/schema override options.

- **Refactors**
  - Deleted exports: DEFAULT_BASE_URL, DEFAULT_HYBRID_ALPHA, Experimental_SchemaOverride, Experimental_PreExecuteFunction, Experimental_ToolCreationOptions.
  - Removed BaseTool.experimental_preExecute and related parameter processing.
  - Simplified Tools.getTool(name) to return the original tool; removed options and schema override logic.

- **Migration**
  - Stop importing DEFAULT_BASE_URL and DEFAULT_HYBRID_ALPHA; set baseUrl via options instead.
  - Remove usage of Experimental_* types and any preExecute or schema override hooks.
  - Update Tools.getTool calls to no longer pass options; use the tool as-is.

<sup>Written for commit e0e7023f9077927032b59c05c2825c050bf92663. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

