### PR TITLE
ci: add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to CI workflow for manual execution
- This allows triggering the CI pipeline manually to re-deploy coverage badges

## Context
The GitHub Pages build type was updated from `legacy` to `workflow` to properly support the `actions/deploy-pages` deployment. This change enables manual workflow runs to redeploy coverage reports when needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workflow_dispatch to the CI workflow to allow manual runs, so we can redeploy coverage badges on demand. This supports the switch to GitHub Pages workflow builds using actions/deploy-pages.

<sup>Written for commit b0cc16a7e26d0e107cf72c53c79717884c6a5d7e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

