### PR TITLE
fix(release): give permission to create id for publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release-please
@@ -24,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created  }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix release CI by scoping permissions to jobs and enabling OIDC for publishing. This unblocks the publish step by granting id-token: write with least-privilege settings.

- **Bug Fixes**
  - Add id-token: write and contents: read to the publish job.
  - Move permissions to job level: release-please job gets contents/pull-requests/issues write; publish job uses minimal permissions.

<sup>Written for commit 5bd9234523c12aa49d5b97bf7bc025814051a30d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

