### PR TITLE
fix(release): enable provence

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,4 +43,4 @@ jobs:
         run: nix develop --command pnpm install --frozen-lockfile
 
       - name: 🚀 Publish package
-        run: nix develop --command pnpm publish --access public --no-git-checks
+        run: nix develop --command pnpm publish --provenance --no-git-checks --access public


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable npm provenance in the release workflow by adding the --provenance flag to pnpm publish. This adds build attestation to releases for better supply chain verification, with no runtime or API changes.

<sup>Written for commit 0b1fe4577efeb9dec34331f6d0329640486d922b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

