### PR TITLE
fix(ci): node latest -> lts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes the release workflow by switching Node.js to LTS and checking out full git history to prevent versioning issues.

- **Bug Fixes**
  - Use Node.js lts/* instead of latest to avoid breaking changes in CI.
  - Set checkout fetch-depth: 0 so release steps can access tags and full history.

<sup>Written for commit 6d689ae329c421aa8ee5197e405739883f72a021. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

