### PR TITLE
fix(ci): move install to nix action

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -13,3 +13,7 @@ runs:
       with:
         name: numtide
         authToken: ''
+
+    - name: Load Nix development environment
+      shell: bash
+      run: nix develop --command true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,6 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Initialise Nix environment
-        run: nix develop --command true
-
       - name: Run Lint
         run: nix develop --command pnpm run lint
 

--- a/.github/workflows/dry-publish.yaml
+++ b/.github/workflows/dry-publish.yaml
@@ -13,8 +13,5 @@ jobs:
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
 
-      - name: Install dependencies
-        run: nix develop --command pnpm install --frozen-lockfile
-
       - name: 🚀 Dry Run Publish Package
         run: nix develop --command pnpm dlx pkg-pr-new publish --pnpm

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,8 +41,5 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
 
-      - name: 💫 Install dependencies
-        run: nix develop --command pnpm install --frozen-lockfile
-
       - name: 🚀 Publish package
         run: nix develop --command pnpm publish --provenance --no-git-checks --access public


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralize Nix environment setup in the shared setup-nix action and remove redundant init/install steps from CI, dry-publish, and release. This reduces duplication and streamlines builds.

- **Refactors**
  - setup-nix: load the Nix dev environment (nix develop --command true).
  - ci.yaml: remove explicit Nix init step.
  - dry-publish.yaml: remove pnpm install; run via nix develop.
  - release.yaml: remove pnpm install; run via nix develop.

<sup>Written for commit a9ce5b882f45d60ec584efaea0e22b1c5ca57fdb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

