### PR TITLE
fix(ci): remove --provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,5 +41,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
 
+      - name: 📦 Pack package
+        run: nix develop --command pnpm pack --no-git-checks
+
       - name: 🚀 Publish package
-        run: nix develop --command pnpm publish --no-git-checks --access public
+        shell: bash
+        run: |
+          PACKAGE_TGZ=$(ls *.tgz | head -n 1)
+          echo "Publishing package: $PACKAGE_TGZ"
+          npm publish "$PACKAGE_TGZ" --access public

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             pnpm_10
+            nodejs_24
           ];
 
           shellHook = ''

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"lint:oxfmt": "oxfmt --no-error-on-unmatched-pattern --check .",
 		"lint:oxlint": "oxlint --max-warnings=0 --type-aware --type-check",
 		"lint:knip": "knip",
-		"preinstall": "npx only-allow pnpm",
 		"prepack": "npm pkg delete scripts.preinstall && pnpm run build",
 		"test": "vitest",
 		"coverage": "vitest run --coverage"


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the release workflow to pack with pnpm and publish the tarball with npm, removing --provenance to fix CI publish failures.

<sup>Written for commit c3f8462c686db8a5835205998c40d571a25927c6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



