### PR TITLE
fix(ci): pack

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           node-version: lts/*
 
       - name: 📦 Pack package
-        run: nix develop --command pnpm pack --no-git-checks
+        run: nix develop --command pnpm pack
 
       - name: 🚀 Publish package
         shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the release workflow pack step by removing the unsupported --no-git-checks flag from pnpm pack. This prevents CI failures and ensures the package packs successfully.

<sup>Written for commit 2c168bdaf97863fcd0e94c72b7a0da95b374061d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

