### PR TITLE
fix(ci): revert changes 2.0.5 ~ 2.0.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,12 +41,5 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
 
-      - name: 📦 Pack package
-        run: nix develop --command pnpm pack --no-git-checks
-
       - name: 🚀 Publish package
-        shell: bash
-        run: |
-          PACKAGE_TGZ=$(ls *.tgz | head -n 1)
-          echo "Publishing package: $PACKAGE_TGZ"
-          npm publish "$PACKAGE_TGZ" --access public
+        run: nix develop --command pnpm publish --provenance --no-git-checks --access public

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,6 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             pnpm_10
-            nodejs_24
           ];
 
           shellHook = ''

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"lint:oxfmt": "oxfmt --no-error-on-unmatched-pattern --check .",
 		"lint:oxlint": "oxlint --max-warnings=0 --type-aware --type-check",
 		"lint:knip": "knip",
+		"preinstall": "npx only-allow pnpm",
 		"prepack": "npm pkg delete scripts.preinstall && pnpm run build",
 		"test": "vitest",
 		"coverage": "vitest run --coverage"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts the release pipeline changes from 2.0.5–2.0.7 to restore direct pnpm publish with provenance. Also tightens local tooling and simplifies the dev shell.

- **Bug Fixes**
  - Release workflow: remove pack step and custom npm publish; use pnpm publish with --provenance and --no-git-checks via nix.
  - flake.nix: drop nodejs_24 from devShell.
  - package.json: add preinstall to enforce pnpm; prepack deletes it before publishing.

<sup>Written for commit e655535d0c08f8b4ee759da4a6a59704a0fb13f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

