### PR TITLE
fix: Revert "fix(ci): revert changes 2.0.5 ~ 2.0.7"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,5 +41,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           node-version: lts/*
 
+      - name: 📦 Pack package
+        run: nix develop --command pnpm pack
+
       - name: 🚀 Publish package
-        run: nix develop --command pnpm publish --provenance --no-git-checks --access public
+        shell: bash
+        run: |
+          PACKAGE_TGZ=$(ls *.tgz | head -n 1)
+          echo "Publishing package: $PACKAGE_TGZ"
+          npm publish "$PACKAGE_TGZ" --access public

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         {
           devShells.default = pkgs.mkShell {
             buildInputs = with pkgs; [
+              nodejs_24
               pnpm_10
               nixfmt-rfc-style
             ];

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"lint:oxfmt": "oxfmt --no-error-on-unmatched-pattern --check .",
 		"lint:oxlint": "oxlint --max-warnings=0 --type-aware --type-check",
 		"lint:knip": "knip",
-		"preinstall": "npx only-allow pnpm",
 		"prepack": "npm pkg delete scripts.preinstall && pnpm run build",
 		"test": "vitest",
 		"coverage": "vitest run --coverage"


### PR DESCRIPTION
Reverts StackOneHQ/stackone-ai-node#246



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the release workflow to pack the package and publish the built .tgz via npm for more reliable releases. Also adds Node.js 24 to the Nix dev shell and removes the pnpm-only preinstall guard.

- **Refactors**
  - Pack with pnpm and publish the tarball with npm in the release job.
  - Add nodejs_24 to the Nix dev shell.
  - Remove the "only-allow pnpm" preinstall script from package.json.

<sup>Written for commit a00dd2f4fd7bb4c33a91785e4e2e1ebc1c6b40a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



