### PR TITLE
fix: remove unified API validation and support

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -18,9 +18,3 @@ export const DEFAULT_BASE_URL = 'https://api.stackone.com';
  * - Higher values favor TF-IDF scoring (better semantic matching)
  */
 export const DEFAULT_HYBRID_ALPHA = 0.2;
-
-/**
- * Prefix used by legacy Unified API tools.
- * Tools with this prefix indicate missing or incorrect account configuration.
- */
-export const UNIFIED_API_PREFIX = 'unified_';

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -35,7 +35,6 @@ const rpcActionResponseDataSchema = z.union([
  * - `next`: Pagination cursor for fetching next page
  *
  * Additional fields from the connector response are passed through.
- * @see unified-cloud-api/src/unified-api-v2/unifiedAPIv2.service.ts processActionCall
  */
 export const rpcActionResponseSchema = z.looseObject({
 	next: z.nullable(z.optional(z.string())),

--- a/src/toolsets.test.ts
+++ b/src/toolsets.test.ts
@@ -250,36 +250,6 @@ describe('StackOneToolSet', () => {
 			const executableTool = (await tool?.toAISDK())?.dummy_action;
 			expect(executableTool?.execute).toBeDefined();
 		});
-
-		it('throws error when receiving unified API tools', async () => {
-			const unifiedToolMcpApp = createMcpApp({
-				accountTools: {
-					'unified-test-account': [
-						{
-							name: 'unified_hris_list_employees',
-							description: 'Unified HRIS tool',
-							inputSchema: { type: 'object', properties: {} },
-						},
-					],
-				},
-			});
-
-			server.use(
-				http.all('https://api.stackone-dev.com/mcp', async ({ request }) => {
-					return unifiedToolMcpApp.fetch(request);
-				}),
-			);
-
-			const toolset = new StackOneToolSet({
-				baseUrl: 'https://api.stackone-dev.com',
-				apiKey: 'test-key',
-				accountId: 'unified-test-account',
-			});
-
-			await expect(toolset.fetchTools()).rejects.toThrow(ToolSetConfigError);
-			await expect(toolset.fetchTools()).rejects.toThrow(/unified API tool/);
-			await expect(toolset.fetchTools()).rejects.toThrow(/unified_hris_list_employees/);
-		});
 	});
 
 	describe('account filtering', () => {

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -1,6 +1,6 @@
 import { defu } from 'defu';
 import type { MergeExclusive, SimplifyDeep } from 'type-fest';
-import { DEFAULT_BASE_URL, UNIFIED_API_PREFIX } from './consts';
+import { DEFAULT_BASE_URL } from './consts';
 import { createFeedbackTool } from './feedback';
 import { type StackOneHeaders, normalizeHeaders, stackOneHeadersSchema } from './headers';
 import { createMCPClient } from './mcp-client';
@@ -314,19 +314,6 @@ export class StackOneToolSet {
 	}
 
 	/**
-	 * Validate that tool name is not from unified API
-	 * Unified API tools indicate missing or incorrect account configuration
-	 */
-	private validateToolName(toolName: string): void {
-		if (toolName.startsWith(UNIFIED_API_PREFIX)) {
-			throw new ToolSetConfigError(
-				`Received unified API tool "${toolName}". This indicates the account is not properly configured. ` +
-					`Unified API tools require versioned connectors. Please check your account's integration setup.`,
-			);
-		}
-	}
-
-	/**
 	 * Fetch tool definitions from MCP
 	 */
 	private async fetchToolsFromMcp(): Promise<Tools> {
@@ -344,8 +331,6 @@ export class StackOneToolSet {
 		const actionsClient = this.getActionsClient();
 
 		const tools = listToolsResult.tools.map(({ name, description, inputSchema }) => {
-			this.validateToolName(name);
-
 			return this.createRpcBackedTool({
 				actionsClient,
 				name,


### PR DESCRIPTION
## Summary

Remove the unified API tool validation that was previously used to detect legacy/misconfigured accounts. This validation is no longer needed as the unified API architecture has been deprecated.

## What Changed

- Remove `UNIFIED_API_PREFIX` constant from `consts.ts`
- Remove `validateToolName()` method from `StackOneToolSet` class
- Remove unified API tool validation call in `fetchTools()`
- Remove `@see` reference to unified-cloud-api in `schema.ts`
- Remove corresponding unit test for unified API tool detection

## Why

The unified API architecture has been deprecated, so the validation code that detected and rejected unified API tools is no longer necessary. This simplifies the codebase by removing obsolete code paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unified API tool validation and references now that the architecture is deprecated. This simplifies tool fetching and avoids throwing configuration errors for unified_-prefixed tools.

- **Refactors**
  - Removed UNIFIED_API_PREFIX from consts.ts
  - Deleted validateToolName and its call in fetchTools
  - Removed unified API unit test
  - Dropped @see unified-cloud-api reference in schema.ts

<sup>Written for commit 18ca8b6db0f951c503af60d6fb8030121ea303c3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

