### PR TITLE
chore: fix typos ignore regex

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,10 +1,10 @@
 [default]
 locale = 'en-us'
 extend-ignore-re = [
-  "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
-  "(?s)<!--\\s*spellchecker:off.*?\\n\\s*spellchecker:on\\s*-->",
+  "(?s)(#|//)\\s*spellchecker:off[\\s\\S]*?(#|//)\\s*spellchecker:on",
+  "(?s)<!--\\s*spellchecker:off\\s*-->[\\s\\S]*?<!--\\s*spellchecker:on\\s*-->",
   "(?Rm)^.*#\\s*spellchecker:disable-line$",
-  "(?m)^.*<!--\\s*spellchecker:disable-line\\s*-->\\n.*$"
+  "(?m)^.*<!--\\s*spellchecker:disable-line\\s*-->\\n.*$",
 ]
 
 [files]


### PR DESCRIPTION
Fixes the typos ignore regex pattern for better handling of multiline spellchecker directives.

- Update spellchecker:off/on regex to use [\s\S]* for matching any characters including newlines
- Apply same fix to HTML comment variant
- Add trailing comma for consistency

This aligns with the fix applied to the Python SDK (stackone-ai-python#74).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the typos ignore regex so spellchecker:off/on correctly ignores multiline blocks, including HTML comments. Switch to [\s\S]* for matching across newlines and add a trailing comma for consistency.

<sup>Written for commit dd8ecb3d9cc5d132c825d566062f33fbdfa4f020. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

