### PR TITLE
fix(toolsets): remove as StackOneHeaders

### DIFF
--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -486,7 +486,7 @@ export class StackOneToolSet {
 				const additionalHeaders = this.extractRecord(parsedParams, 'headers');
 				const extraHeaders = normalizeHeaders(additionalHeaders);
 				// defu merges extraHeaders into baseHeaders, both are already branded types
-				const actionHeaders = defu(extraHeaders, baseHeaders) as StackOneHeaders;
+				const actionHeaders = defu(extraHeaders, baseHeaders);
 
 				const bodyPayload = this.extractRecord(parsedParams, 'body');
 				const rpcBody: JsonObject = bodyPayload ? { ...bodyPayload } : {};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unnecessary "as StackOneHeaders" cast when merging headers into actionHeaders in StackOneToolSet. This fixes a TypeScript type error and lets the branded header type be inferred from baseHeaders and extraHeaders.

<sup>Written for commit d7a2a907d0b2ac6a0b8516952d23ef6a71286ed5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

