### PR TITLE
ci(nix): add Nix store caching to setup-nix action

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -1,10 +1,10 @@
 name: 'Setup Nix'
-description: 'Install Nix and configure Cachix'
+description: 'Install Nix and configure cache'
 runs:
   using: 'composite'
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@0b0e072294b088b73964f1d72dfdac0951439dbd # v31.8.4
+      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
       with:
         github_access_token: ${{ github.token }}
 
@@ -12,12 +12,6 @@ runs:
       uses: nix-community/cache-nix-action@b426b118b6dc86d6952988d396aa7c6b09776d08 # v7
       with:
         primary-key: nix-${{ runner.os }}
-
-    - name: Setup Cachix (numtide)
-      uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-      with:
-        name: numtide
-        authToken: ''
 
     - name: Load Nix development environment
       shell: bash


### PR DESCRIPTION
Add `nix-community/cache-nix-action` to cache the Nix store between CI runs. This speeds up subsequent builds by avoiding redundant downloads and builds of Nix dependencies.

Inspired by [skanehira/version-lsp](https://github.com/skanehira/version-lsp/blob/main/.github/workflows/ci.yaml#L118-L121).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Nix store caching to the setup-nix action to speed up CI by reusing built dependencies between runs and avoiding redundant downloads/builds. Replace Cachix with nix-community/cache-nix-action and bump install-nix-action to v31.9.0; the cache key is scoped to the runner OS (e.g., nix-Linux, nix-macOS).

<sup>Written for commit 96bcc8eb21b96f9ab32566c4910724e6e7a55128. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

