### PR TITLE
chore: update github actions

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -9,7 +9,7 @@ runs:
         github_access_token: ${{ github.token }}
 
     - name: Cache Nix store
-      uses: nix-community/cache-nix-action@b426b118b6dc86d6952988d396aa7c6b09776d08 # v7
+      uses: nix-community/cache-nix-action@b426b118b6dc86d6952988d396aa7c6b09776d08 # v7.0.0
       with:
         primary-key: nix-${{ runner.os }}
 

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@6337623ebba10cf8c8214b507993f8062fd4ccfb # v1.0.22
+        uses: anthropics/claude-code-action@7145c3e0510bcdbdd29f67cc4a8c1958f1acfa2f # v1.0.27
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: 'Bash,mcp__context7__resolve-library-id,mcp__context7__get-library-docs'

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -23,7 +23,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for CI to pass
-        uses: lewagon/wait-on-check-action@ccfb013c15c8afb7bf2b7c028fb74dc5a068cccc # v1.3.4
+        uses: lewagon/wait-on-check-action@3603e826ee561ea102b58accb5ea55a1a7482343 # v1.4.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: Dependabot auto-merge

--- a/.github/workflows/nix-flake-update.yaml
+++ b/.github/workflows/nix-flake-update.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup Nix
         uses: ./.github/actions/setup-nix
@@ -35,7 +35,7 @@ jobs:
       - name: Create Pull Request
         id: create-pr
         if: steps.check-changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(deps): update nix flake inputs'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated GitHub Actions to newer versions across workflows to improve reliability and security. No behavior changes expected.

- **Dependencies**
  - anthropics/claude-code-action: v1.0.27 (was v1.0.22)
  - lewagon/wait-on-check-action: v1.4.1 (was v1.3.4)
  - actions/checkout: v6.0.1 (was v4.3.1)
  - peter-evans/create-pull-request: v8.0.0 (was v7.0.11)
  - nix-community/cache-nix-action: comment updated to v7.0.0 (SHA unchanged)

<sup>Written for commit c68824c1619bcbd9de473aabc30c1cb3b4d07737. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

