### PR TITLE
ci(nix): include all Nix files and lockfiles in cache key hash

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -11,7 +11,7 @@ runs:
     - name: Cache Nix store
       uses: nix-community/cache-nix-action@b426b118b6dc86d6952988d396aa7c6b09776d08 # v7.0.0
       with:
-        primary-key: nix-${{ runner.os }}
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', 'flake.lock', 'pnpm-lock.yaml') }}
 
     - name: Load Nix development environment
       shell: bash


### PR DESCRIPTION
## Summary

- Add `hashFiles` for all `*.nix` files, `flake.lock`, and `pnpm-lock.yaml` to the Nix store cache key
- Ensures cache is properly invalidated when Nix configuration or dependency lockfiles change

## Test plan

- [ ] Verify CI runs successfully with the new cache key

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include all *.nix files, flake.lock, and pnpm-lock.yaml in the CI Nix cache key using hashFiles to avoid stale caches. This ensures the Nix store cache invalidates when Nix config or dependency locks change.

<sup>Written for commit 1d9de93eaa991bc0f7ad097b648b25978348571b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

