### PR TITLE
chore(lefthook): add lockfile integrity and dependency change checks

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -21,7 +21,7 @@ pre-push:
     - name: knip
       run: pnpm run lint:knip
     - name: lockfile-sync-check
-      glob: '{package.json,pnpm-workspace.yaml}'
+      glob: '{**/package.json,pnpm-workspace.yaml}'
       run: pnpm install --lockfile-only --frozen-lockfile
     - name: lint-all-on-lockfile-change
       glob: 'pnpm-lock.yaml'


### PR DESCRIPTION
## Summary

Add pre-push checks to ensure dependency changes are properly validated:

- **lockfile-sync-check**: Verify `package.json`/`pnpm-workspace.yaml` changes are reflected in `pnpm-lock.yaml`
- **lint-all-on-lockfile-change**: Run full lint when lockfile changes
- **test-all-on-lockfile-change**: Run full test suite when lockfile changes

## Why

Ensures that dependency changes don't break the build and that lockfile stays in sync with package manifests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pre-push lefthook checks to keep the pnpm lockfile in sync and validate dependency changes. This blocks pushes when manifests and the lockfile diverge, and runs full lint/tests on lockfile changes.

- **New Features**
  - lockfile-sync-check: verify pnpm-lock.yaml matches all package.json files and pnpm-workspace.yaml using pnpm install --lockfile-only --frozen-lockfile
  - lint-all-on-lockfile-change: run pnpm lint when pnpm-lock.yaml changes
  - test-all-on-lockfile-change: run pnpm test when pnpm-lock.yaml changes

<sup>Written for commit d65855f59d824886dd660cff60dbb46454a4c5ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

