### PR TITLE
refactor(deps): move zod to peerDependencies with v4-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ The StackOne AI SDK provides the `StackOneToolSet` class, which fetches tools dy
 
 ```bash
 # Using npm
-npm install @stackone/ai
+npm install @stackone/ai zod
 
 # Using yarn
-yarn add @stackone/ai
+yarn add @stackone/ai zod
 
 # Using pnpm
-pnpm add @stackone/ai
+pnpm add @stackone/ai zod
 
 # Using bun
-bun add @stackone/ai
+bun add @stackone/ai zod
 ```
+
+> **Note:** `zod` is a peer dependency required for AI SDK integrations and internal schema validation. Version `>=3.25.0 <5` is supported.
 
 ## Usage
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,8 @@
 		"@tanstack/ai": "catalog:examples",
 		"@tanstack/ai-openai": "catalog:examples",
 		"ai": "catalog:peer",
-		"openai": "catalog:peer"
+		"openai": "catalog:peer",
+		"zod": "catalog:dev"
 	},
 	"devDependencies": {
 		"@types/node": "catalog:dev",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "catalog:prod",
 		"@orama/orama": "catalog:prod",
-		"defu": "catalog:prod",
-		"zod": "catalog:prod"
+		"defu": "catalog:prod"
 	},
 	"devDependencies": {
 		"@ai-sdk/provider": "catalog:dev",
@@ -78,12 +77,14 @@
 		"type-fest": "catalog:dev",
 		"typescript": "catalog:dev",
 		"unplugin-unused": "catalog:dev",
-		"vitest": "catalog:dev"
+		"vitest": "catalog:dev",
+		"zod": "catalog:dev"
 	},
 	"peerDependencies": {
 		"@anthropic-ai/sdk": "catalog:peer",
 		"ai": "catalog:peer",
-		"openai": "catalog:peer"
+		"openai": "catalog:peer",
+		"zod": "catalog:peer"
 	},
 	"peerDependenciesMeta": {
 		"@anthropic-ai/sdk": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     vitest:
       specifier: ^4.0.15
       version: 4.0.15
+    zod:
+      specifier: ^4.1.13
+      version: 4.1.13
   examples:
     '@anthropic-ai/claude-agent-sdk':
       specifier: ^0.1.67
@@ -102,9 +105,6 @@ catalogs:
     defu:
       specifier: ^6.1.4
       version: 6.1.4
-    zod:
-      specifier: ^4.1.13
-      version: 4.1.13
 
 importers:
 
@@ -122,9 +122,6 @@ importers:
       defu:
         specifier: catalog:prod
         version: 6.1.4
-      zod:
-        specifier: catalog:prod
-        version: 4.1.13
     devDependencies:
       '@ai-sdk/provider':
         specifier: catalog:dev
@@ -195,6 +192,9 @@ importers:
       vitest:
         specifier: catalog:dev
         version: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+      zod:
+        specifier: catalog:dev
+        version: 4.1.13
 
   examples:
     dependencies:
@@ -225,6 +225,9 @@ importers:
       openai:
         specifier: catalog:peer
         version: 6.9.1(zod@4.1.13)
+      zod:
+        specifier: catalog:dev
+        version: 4.1.13
     devDependencies:
       '@types/node':
         specifier: catalog:dev

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ catalogs:
     typescript: ^5.8.3
     unplugin-unused: ^0.5.4
     vitest: ^4.0.15
+    zod: ^4.1.13
   examples:
     '@anthropic-ai/claude-agent-sdk': ^0.1.67
     '@tanstack/ai': ^0.0.3
@@ -36,11 +37,11 @@ catalogs:
     '@anthropic-ai/sdk': ^0.52.0
     ai: ^5.0.108
     openai: ^6.2.0
+    zod: '>=3.25.0 <5'
   prod:
     '@modelcontextprotocol/sdk': ^1.24.3
     '@orama/orama': ^3.1.11
     defu: ^6.1.4
-    zod: ^4.1.13
 
 enablePrePostScripts: true
 

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { DEFAULT_BASE_URL } from './consts';
 import { BaseTool } from './tool';
 import type { ExecuteConfig, ExecuteOptions, JsonObject, JsonValue, ToolParameters } from './types';

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/mini';
+import { z } from 'zod/v4-mini';
 import type { JsonObject } from './types';
 
 /**

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/mini';
+import { z } from 'zod/v4-mini';
 import { stackOneHeadersSchema } from './headers';
 
 /**


### PR DESCRIPTION
## Summary

- Move zod from dependencies to peerDependencies (`>=3.25.0 <5`)
- Use `zod/v4-mini` subpath for smaller bundle size in schema/headers
- Use `zod/v4` subpath in feedback.ts (requires `.transform`/`.refine`)
- Add zod to devDependencies and examples for development/testing

## Why

This allows users to bring their own zod version (3.25+ or 4.x) while ensuring compatibility with AI SDK's zod peer dependency. The `zod/v4-mini` variant reduces bundle size for simple schemas.

## Test plan

- [x] All tests pass
- [x] Lint passes