### PR TITLE
chore(lefthook): run pre-push in parallel

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -17,6 +17,7 @@ pre-commit:
       stage_fixed: true
 
 pre-push:
+  parallel: true
   jobs:
     - name: knip
       run: pnpm run lint:knip


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run pre-push Lefthook jobs in parallel to reduce push wait time.

Enabled parallel execution by setting parallel: true in lefthook.yaml.

<sup>Written for commit d47156f63beb17166b05524e26f627f3c9d7eb88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

