### PR TITLE
chore(publish): exclude all test files from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.mts",
 	"files": [
-		"!example/*.test.ts",
+		"!examples/*.test.ts",
+		"!src/**/*.test-d.ts",
+		"!src/**/*.test.ts",
 		"LICENSE",
 		"README.md",
 		"dist",


### PR DESCRIPTION
Exclude all test files from the published npm package by updating the `files` field exclusion patterns.

**Changes:**
- Add `!examples/*.test.ts` to exclude example test files
- Add `!src/**/*.test.ts` to exclude unit test files
- Add `!src/**/*.test-d.ts` to exclude type test files

The previous pattern `!**/*.test.ts` at the start didn't work because npm applies negation patterns only to already-included files.