### PR TITLE
chore(nix): remove flake-parts dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1767609335,
-        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767364772,
@@ -34,24 +16,8 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,22 +3,26 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs =
-    inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+    { nixpkgs, ... }:
+    let
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
       ];
-
-      perSystem =
-        { pkgs, ... }:
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
         {
-          devShells.default = pkgs.mkShell {
+          default = pkgs.mkShell {
             buildInputs = with pkgs; [
               # runtime
               nodejs_24
@@ -42,6 +46,7 @@
               fi
             '';
           };
-        };
+        }
+      );
     };
 }


### PR DESCRIPTION
## Summary
- Remove flake-parts dependency from flake.nix
- Use standard `nixpkgs.lib.genAttrs` pattern for multi-system support
- Simplify the flake configuration while maintaining identical functionality

## Rationale
The devShell configuration is simple enough that flake-parts adds unnecessary complexity. Using the standard Nix pattern reduces dependencies without losing any functionality.

## Test plan
- [ ] Run `nix develop` and verify the shell works correctly
- [ ] Verify all buildInputs are available (nodejs_24, pnpm_10, etc.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed flake-parts and switched to nixpkgs.lib.genAttrs to generate devShells across systems. Functionality stays the same, with a simpler flake.

- **Refactors**
  - Defined devShells per system using forAllSystems and nixpkgs.legacyPackages, keeping the same buildInputs.

- **Dependencies**
  - Removed flake-parts and nixpkgs-lib entries from flake.lock.

<sup>Written for commit 1f0f1b3a78111dfef8ddd168b85d25702884eaa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

