### PR TITLE
chore(nix): use mkShellNoCC for lighter dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          default = pkgs.mkShell {
+          default = pkgs.mkShellNoCC {
             buildInputs = with pkgs; [
               # runtime
               nodejs_24


### PR DESCRIPTION
Switch from `mkShell` to `mkShellNoCC` since this project doesn't require a C compiler toolchain. This reduces unnecessary dependencies and speeds up shell initialisation for Node.js/pnpm development.

Also updates flake.lock to latest inputs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use mkShellNoCC for the Nix dev shell to remove the C toolchain. This cuts unnecessary dependencies and speeds up shell startup for Node.js/pnpm.

<sup>Written for commit 6b1c7d3c9bcfde21b83160067ffe323ba30be23c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

