### PR TITLE
chore: remove typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
 		"publint": "catalog:dev",
 		"tsdown": "catalog:dev",
 		"type-fest": "catalog:dev",
-		"typescript": "catalog:dev",
 		"unplugin-unused": "catalog:dev",
 		"vitest": "catalog:dev",
 		"zod": "catalog:dev"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,6 @@ catalogs:
     type-fest:
       specifier: ^4.41.0
       version: 4.41.0
-    typescript:
-      specifier: ^5.8.3
-      version: 5.9.3
     unplugin-unused:
       specifier: ^0.5.4
       version: 0.5.6
@@ -180,9 +177,6 @@ importers:
       type-fest:
         specifier: catalog:dev
         version: 4.41.0
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
       unplugin-unused:
         specifier: catalog:dev
         version: 0.5.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,6 @@ catalogs:
     publint: ^0.3.12
     tsdown: ^0.17.2
     type-fest: ^4.41.0
-    typescript: ^5.8.3
     unplugin-unused: ^0.5.4
     vitest: ^4.0.15
     zod: ^4.3.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed TypeScript from package.json catalog aliases, pnpm-workspace.yaml catalogs, and pnpm-lock.yaml entries because it’s no longer needed. This cleans up an unused dependency and slightly reduces install size and time.

<sup>Written for commit f152d950da1c4e0bf76fcc978f29cc1a123537c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

