### PR TITLE
chore(nix): update nixfmt-rfc-style to nixfmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
               # formatting and linting tools
               similarity
-              nixfmt-rfc-style
+              nixfmt
               tsgolint
               oxlint
               oxfmt


### PR DESCRIPTION
Updates the Nix flake to use `nixfmt` instead of `nixfmt-rfc-style`. The RFC 166 formatting style has been merged into nixfmt as of Nix 2.24, making the separate package unnecessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch devShell formatter from nixfmt-rfc-style to nixfmt. RFC 166 formatting is now default in nixfmt on Nix 2.24, so the separate package is unnecessary.

<sup>Written for commit 89ee36a823223a06363befa60bf0051b9b9581f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

