### PR TITLE
chore(nix): migrate lefthook from npm to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,9 @@
 
               # security
               gitleaks
+
+              # git hooks
+              lefthook
             ];
 
             shellHook = ''
@@ -47,6 +50,9 @@
                 echo "📦 Installing dependencies..."
                 pnpm install --frozen-lockfile
               fi
+
+              # Install lefthook git hooks
+              lefthook install > /dev/null 2>&1
             '';
           };
         }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
 		"ai": "catalog:dev",
 		"hono": "catalog:dev",
 		"knip": "catalog:dev",
-		"lefthook": "catalog:dev",
 		"msw": "catalog:dev",
 		"openai": "catalog:peer",
 		"publint": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ catalogs:
     knip:
       specifier: ^5.72.0
       version: 5.72.0
-    lefthook:
-      specifier: ^2.0.8
-      version: 2.0.8
     msw:
       specifier: ^2.10.4
       version: 2.12.3
@@ -138,9 +135,6 @@ importers:
       knip:
         specifier: catalog:dev
         version: 5.72.0(@types/node@22.19.1)(typescript@5.9.3)
-      lefthook:
-        specifier: catalog:dev
-        version: 2.0.8
       msw:
         specifier: catalog:dev
         version: 2.12.3(@types/node@22.19.1)(typescript@5.9.3)
@@ -1674,60 +1668,6 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
-
-  lefthook-darwin-arm64@2.0.8:
-    resolution: {integrity: sha512-Nu52qmqhSP+DKKuKYKDkMkPbgvgTZv+ueEo1LVXidTcgxEwvrbe2balcdqdulQTsPfYtm3pCPvv8ikalHrH+Qg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@2.0.8:
-    resolution: {integrity: sha512-EGNBw1vuXzphs/KyDchkglwnYNkKQH3EpptIPXcQCRC3WKiz87PSrwkOxjGtgDg6nLYWru3YUzgcFrIGUXjWPw==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@2.0.8:
-    resolution: {integrity: sha512-ZPua6y7y7l/0PpMJhU1ZAt4jl0dC3F+EGlSzy9v0vqzyoixk0HRqsz9nxN7wmJo/5vHhHJBjsE5/sEYS9Z8tsQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@2.0.8:
-    resolution: {integrity: sha512-ab9M5gCsMeYzOeBoHIOz+zyVSnEZowwV2jn3Am+x625ZNcqU0T3eNf+a7ppopvkQjrehfmO3y5HiMVAkSAs1Vw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@2.0.8:
-    resolution: {integrity: sha512-BaoUKmwnAbWssSwVHoA0HyJFX3m+Mp6xJhxD4YAu8H1mo8DNOWBG5J7DGXJRIiBTm6YjAXlerq8Pjfx4lycfYQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@2.0.8:
-    resolution: {integrity: sha512-oNXcoGWsGy/U9gqE6PJpLtiNlGlAgoYtVmfc2gauNPRJehaQBaifD5/5aXPiWhRukUTQ1p9kuShFDpT2jOYn5Q==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@2.0.8:
-    resolution: {integrity: sha512-pxUgnilqsnDEWF7J5uNViHJ+Q4gSEQbRbrcIEdluBzjW34E20WK4UPk0bxZDQZAeaXTubNQEvyafmfY7dWe4Gg==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@2.0.8:
-    resolution: {integrity: sha512-p50cpkWImLwU330JJuJaioNVT1X/Z56iqPOLEgBt2+1BlljmPe/eGrMArF4iIKfdZ4wFJ9f2h0gq+jyvQGFjSg==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@2.0.8:
-    resolution: {integrity: sha512-dStshOCvmg9sQSUmWNiLMLv52HFTVxC9JE2HGxCiHcK5oqVZS2v9cCZdFdiDZ1Xldi3ozLi2y7/Xpzul8Oqv5Q==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@2.0.8:
-    resolution: {integrity: sha512-2YgT6feliy6CCDwbkT3pg1ylKD1b9lj+O5NdLsrxvZGRmO6ftXleWB4xfWKGGY8FrzAD2Y3eEVDv5n3NvGHDzw==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@2.0.8:
-    resolution: {integrity: sha512-FozDCKeSI+m3BP0cvyPgHch+yf7ClS3hDy1JsRUrbNmlyjqBcmlygnRXsZzpH+wHoNnF2fmfhJhkx/7S7IpaVw==}
-    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3596,49 +3536,6 @@ snapshots:
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       zod: 4.3.5
-
-  lefthook-darwin-arm64@2.0.8:
-    optional: true
-
-  lefthook-darwin-x64@2.0.8:
-    optional: true
-
-  lefthook-freebsd-arm64@2.0.8:
-    optional: true
-
-  lefthook-freebsd-x64@2.0.8:
-    optional: true
-
-  lefthook-linux-arm64@2.0.8:
-    optional: true
-
-  lefthook-linux-x64@2.0.8:
-    optional: true
-
-  lefthook-openbsd-arm64@2.0.8:
-    optional: true
-
-  lefthook-openbsd-x64@2.0.8:
-    optional: true
-
-  lefthook-windows-arm64@2.0.8:
-    optional: true
-
-  lefthook-windows-x64@2.0.8:
-    optional: true
-
-  lefthook@2.0.8:
-    optionalDependencies:
-      lefthook-darwin-arm64: 2.0.8
-      lefthook-darwin-x64: 2.0.8
-      lefthook-freebsd-arm64: 2.0.8
-      lefthook-freebsd-x64: 2.0.8
-      lefthook-linux-arm64: 2.0.8
-      lefthook-linux-x64: 2.0.8
-      lefthook-openbsd-arm64: 2.0.8
-      lefthook-openbsd-x64: 2.0.8
-      lefthook-windows-arm64: 2.0.8
-      lefthook-windows-x64: 2.0.8
 
   magic-string@0.30.21:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,6 @@ catalogs:
     '@vitest/coverage-v8': ^4.0.15
     hono: ^4.9.10
     knip: ^5.72.0
-    lefthook: ^2.0.8
     msw: ^2.10.4
     publint: ^0.3.12
     tsdown: ^0.17.2
@@ -55,7 +54,6 @@ minimumReleaseAgeExclude:
 
 onlyBuiltDependencies:
   - esbuild
-  - lefthook
   - msw
 
 shellEmulator: true


### PR DESCRIPTION
## Summary

Migrates lefthook from pnpm devDependencies to nix flake for consistent tooling across the team.

## What Changed

- Added lefthook to `flake.nix` buildInputs
- Added `lefthook install` to shellHook for automatic git hooks setup on devshell entry
- Removed lefthook from `package.json` devDependencies
- Removed lefthook from `pnpm-workspace.yaml` catalog and `onlyBuiltDependencies`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Lefthook from pnpm to the Nix flake for consistent versions and simpler setup. Git hooks now auto-install when entering the devshell.

- **Refactors**
  - Added lefthook to flake.nix buildInputs and shellHook runs `lefthook install`.
  - Removed lefthook from package.json and pnpm-workspace.yaml (catalog, onlyBuiltDependencies).
  - Removed lefthook binaries and entries from pnpm-lock.yaml.

- **Migration**
  - Use `nix develop` to get hooks installed; pnpm no longer manages lefthook.
  - If hooks aren’t present, re-enter the devshell or run `lefthook install`.

<sup>Written for commit bd7d7f0747c14dd103ed6dc6cf4024c0f3af13ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

