### PR TITLE
perf(ci): switch to nix-quick-install-action for faster CI

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -13,9 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
-      with:
-        github_access_token: ${{ github.token }}
+      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
 
     - name: Install tools from nixpkgs
       shell: bash


### PR DESCRIPTION
## Summary

- Replace `cachix/install-nix-action` with `nixbuild/nix-quick-install-action`
- Expected to reduce Nix installation time from ~30-60s to ~1s on Linux

## Key differences

| Aspect | Before (cachix) | After (nixbuild) |
|--------|-----------------|------------------|
| Install time | ~30-60s | ~1s (Linux) |
| Mode | multi-user (daemon) | single-user (no daemon) |
| Determinism | Variable | Fully deterministic |

## Test plan

- [ ] CI passes (lint, build, test jobs)
- [ ] Compare CI run times before/after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI to nixbuild/nix-quick-install-action for faster, deterministic single-user Nix installs. Measured improvement: Nix setup ~24% faster (25s → 19s) on Linux.

- **Dependencies**
  - Replace cachix/install-nix-action with nixbuild/nix-quick-install-action (single-user, no daemon).

<sup>Written for commit 5f8b8778e87ff792d2332f582aa42de02a28c4d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

