### PR TITLE
Revert "perf(ci): switch to nix-quick-install-action for faster CI"

### DIFF
--- a/.github/actions/setup-nix/action.yaml
+++ b/.github/actions/setup-nix/action.yaml
@@ -13,7 +13,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install Nix
-      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+      uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31.9.0
+      with:
+        github_access_token: ${{ github.token }}
 
     - name: Install tools from nixpkgs
       shell: bash


### PR DESCRIPTION
Reverts StackOneHQ/stackone-ai-node#298

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the previous switch to nix-quick-install-action in CI to restore the prior Nix install flow.

- **Dependencies**
  - Use cachix/install-nix-action@v31.9.0 in setup-nix.
  - Pass github_access_token: ${{ github.token }} for authenticated installs.

<sup>Written for commit 203a571805ab9b71ca479a03355e722619b1d9c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

