### PR TITLE
chore: move tsgo to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
               # runtime
               nodejs_24
               pnpm_10
+              typescript-go
 
               # formatting and linting tools
               similarity

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
 		"@fast-check/vitest": "catalog:dev",
 		"@hono/mcp": "catalog:dev",
 		"@types/node": "catalog:dev",
-		"@typescript/native-preview": "catalog:dev",
 		"@vitest/coverage-v8": "catalog:dev",
 		"ai": "catalog:dev",
 		"hono": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@types/node':
       specifier: ^22.13.5
       version: 22.19.1
-    '@typescript/native-preview':
-      specifier: ^7.0.0-dev.20251209.1
-      version: 7.0.0-dev.20251209.1
     '@vitest/coverage-v8':
       specifier: ^4.0.15
       version: 4.0.15
@@ -120,9 +117,6 @@ importers:
       '@types/node':
         specifier: catalog:dev
         version: 22.19.1
-      '@typescript/native-preview':
-        specifier: catalog:dev
-        version: 7.0.0-dev.20251209.1
       '@vitest/coverage-v8':
         specifier: catalog:dev
         version: 4.0.15(vitest@4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.1)(jiti@2.6.1)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2))
@@ -3013,6 +3007,7 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20251209.1
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251209.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20251209.1
+    optional: true
 
   '@vercel/oidc@3.0.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalogs:
     '@clack/prompts': ^0.11.0
     '@hono/mcp': ^0.1.4
     '@types/node': ^22.13.5
-    '@typescript/native-preview': ^7.0.0-dev.20251209.1
     '@vitest/coverage-v8': ^4.0.15
     hono: ^4.9.10
     knip: ^5.72.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved tsgo to the Nix dev shell so it’s installed and versioned via Nix instead of npm. Also removed the unused @typescript/native-preview to trim dev dependencies.

- **Migration**
  - Use nix develop (or direnv) to get tsgo on PATH.
  - No runtime changes.

<sup>Written for commit dfd5166b9f44fbf25af98d284144bb29feb91377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

