### PR TITLE
chore(lint): add no-param-reassign rule

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -42,6 +42,8 @@
 		"no-empty": "error",
 		// Disallow empty functions
 		"no-empty-function": "error",
+		// Disallow reassigning function parameters
+		"no-param-reassign": "error",
 		// ===================
 		// Override category defaults with custom options
 		// ===================


### PR DESCRIPTION
Add the `no-param-reassign` rule to oxlint configuration. This prevents reassignment of function parameters, enforcing immutability and avoiding subtle bugs caused by unexpected parameter mutation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the no-param-reassign rule in oxlint to block reassigning function parameters. This enforces immutability and prevents subtle bugs from unexpected parameter mutation.

<sup>Written for commit 7fbbab6e49f4ee5eed492b6db1d012be23d4d3f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

