### PR TITLE
chore(lint): use external schema URLs for oxlint/oxfmt configs

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "./node_modules/oxfmt/configuration_schema.json",
+	"$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxfmt/configuration_schema.json",
 	"useTabs": true,
 	"semi": true,
 	"singleQuote": true,

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "./node_modules/oxlint/configuration_schema.json",
+	"$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
 	// Enable TypeScript, Unicorn, Oxc, Node, JSDoc, and Import plugins
 	"plugins": ["typescript", "unicorn", "oxc", "node", "jsdoc", "import"],
 	// Environment settings


### PR DESCRIPTION
## Summary
- Use remote schema URLs from oxc-project/oxc repository instead of local node_modules paths
- This ensures schema validation works even before dependencies are installed

Inspired by https://github.com/ryoppippi/gray-matter-es/pull/5

## Test plan
- [x] `pnpm lint` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the $schema fields in .oxlintrc.jsonc and .oxfmtrc.jsonc to the oxc-project remote URLs. Schema validation and editor hints now work even before dependencies are installed.

<sup>Written for commit 9f0a89626be2c5c9f901ebd49ee675c60a8fe52d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

