### PR TITLE
chore: remove unused comment

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,6 @@ shellEmulator: true
 # Prevents Shai-Hulud-style worm attacks that exploit automatic script execution
 strictDepBuilds: true
 
-# Replaces onlyBuiltDependencies and ignoredBuiltDependencies (pnpm 10.26+)
 # true: allow build scripts, false: block build scripts
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
Removes an unused comment from pnpm-workspace.yaml to keep the configuration file clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an outdated comment from pnpm-workspace.yaml. Keeps the config clean and avoids confusion around allowBuilds.

<sup>Written for commit 345cc36c4d20bee187b8070bb7b69af2f8a58c25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

