### PR TITLE
chore(skills): add release-please skill for triggering versioned releases

### DIFF
--- a/.claude/skills/release-please/SKILL.md
+++ b/.claude/skills/release-please/SKILL.md
@@ -1,0 +1,51 @@
+# Release Please Trigger
+
+Trigger a release-please PR for a specific version.
+
+## Usage
+
+```
+/release-please <version>
+```
+
+## Examples
+
+```
+/release-please 2.3.0
+/release-please 3.0.0
+```
+
+## Instructions
+
+When this skill is invoked with a version argument:
+
+1. **Validate the version format**: Ensure the version follows semantic versioning (X.Y.Z format)
+
+2. **Create a new branch**: Create a branch named `chore/trigger-release-<version>`
+
+   ```bash
+   git switch -c chore/trigger-release-<version>
+   ```
+
+3. **Create an empty commit with Release-As trailer**: The commit message must include the `Release-As: <version>` trailer to trigger release-please
+
+   ```bash
+   git commit --allow-empty -m "chore: trigger release <version>
+
+   Release-As: <version>"
+   ```
+
+4. **Push the branch and create a PR**:
+
+   ```bash
+   git push -u origin chore/trigger-release-<version>
+   gh pr create --title "chore: trigger release <version>" --body "Trigger release-please to create version <version>."
+   ```
+
+5. **Report the PR URL** to the user
+
+## Notes
+
+- The `Release-As` trailer in the commit message tells release-please to use that specific version
+- Once the PR is merged to main, release-please will automatically create a release PR with the specified version
+- The release PR will update CHANGELOG.md, version files, and create a GitHub release when merged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Available Skills
 
-| Skill                 | When to Use                            |
-| --------------------- | -------------------------------------- |
-| **orama-integration** | Integrating with Orama search/indexing |
+| Skill                 | Usage                       | Description                                        |
+| --------------------- | --------------------------- | -------------------------------------------------- |
+| **orama-integration** | N/A                         | Integrating with Orama search/indexing             |
+| **release-please**    | `/release-please <version>` | Trigger a release-please PR for a specific version |


### PR DESCRIPTION
## Summary

Add a new Claude Code skill that automates the release-please workflow for triggering specific version releases.

## What Changed

- Added `.claude/skills/release-please/SKILL.md` with instructions for the `/release-please <version>` command
- Updated `CLAUDE.md` Available Skills table with the new skill

## Usage

```
/release-please 2.3.0
```

This creates a branch with a `Release-As: <version>` commit trailer, then opens a PR that triggers release-please to create a release for that version when merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release-please skill to trigger a specific version release via `/release-please <version>`. It validates semver, creates a branch with a Release-As commit, and opens a PR that produces the release when merged.

<sup>Written for commit 524eba672d30ef98a64b7558fb0391f010941f7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

