### PR TITLE
chore(skills): add .agents/skills directory for Codex compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,5 @@ dist
 
 # Agent skills (managed by Nix via agent-skills-nix)
 .claude/skills
-.codex/skills
-.opencode/skills
+.agents/skills
 

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,12 @@
               enable = true;
               systems = [ ];
             };
+            agents = {
+              dest = ".agents/skills";
+              structure = "symlink-tree";
+              enable = true;
+              systems = [ ];
+            };
           };
         in
         {


### PR DESCRIPTION
## Summary

Add `.agents/skills` as a target for agent-skills-nix alongside `.claude/skills`.

## Why

The `.agents/skills` directory is used by Codex and other coding agents as a standard location for skills. This ensures skills are available to multiple AI coding assistants.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added .agents/skills as a managed skills directory via agent-skills-nix (symlink-tree), alongside .claude/skills, to align with Codex and other agents. Updated .gitignore to ignore .agents/skills and removed deprecated .codex/skills and .opencode/skills entries.

- **Migration**
  - Update any agent configs or scripts from .codex/skills or .opencode/skills to .agents/skills.
  - Move or remove old directories to avoid accidental commits.

<sup>Written for commit 4f02b1b259bab90db322decda27853991bb0d822. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

