### PR TITLE
refactor(skills): use defaultLocalTargets from agent-skills-nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,6 @@ dist
 !.envrc
 
 # Agent skills (managed by Nix via agent-skills-nix)
-.claude/skills
 .agents/skills
+.claude/skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Rules and Skills Structure
 
 - **Rules** (`.claude/rules/`): Automatically loaded based on file paths. Source of truth for project conventions.
-- **Skills** (`.claude/skills/`): Managed by Nix via [agent-skills-nix](https://github.com/Kyure-A/agent-skills-nix). Skills are sourced from [StackOneHQ/skills](https://github.com/StackOneHQ/skills) and installed automatically when entering `nix develop`.
+- **Skills** (`.agents/skills/`, `.claude/skills/`): Managed by Nix via [agent-skills-nix](https://github.com/Kyure-A/agent-skills-nix). Skills are sourced from [StackOneHQ/skills](https://github.com/StackOneHQ/skills) and installed automatically when entering `nix develop`.
 - **Cursor rules** (`.cursor/rules/`): Symlinks to `.claude/rules/` for consistency.
 
 ## Available Rules

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769944375,
-        "narHash": "sha256-TmTyQvFz8rNCwN8MQZGFtgFGdJANF6P6nbxVOjQvpME=",
+        "lastModified": 1770218103,
+        "narHash": "sha256-InxSZomi7ajBm+d5dN3Yah5mh7+pTb3iuI3U380sqQ8=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "bb2fc09cd0152867bd548422e66f4738b081d719",
+        "rev": "2e53d1a4c0fe78d758b99f5df0f79d558498002e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -56,20 +56,9 @@
           pkgs = nixpkgs.legacyPackages.${system};
           bundle = agentLib.mkBundle { inherit pkgs selection; };
           # Use symlink-tree instead of copy-tree for skills
-          localTargets = {
-            claude = {
-              dest = ".claude/skills";
-              structure = "symlink-tree";
-              enable = true;
-              systems = [ ];
-            };
-            agents = {
-              dest = ".agents/skills";
-              structure = "symlink-tree";
-              enable = true;
-              systems = [ ];
-            };
-          };
+          localTargets = nixpkgs.lib.mapAttrs (
+            _: t: t // { structure = "symlink-tree"; }
+          ) agentLib.defaultLocalTargets;
         in
         {
           default = pkgs.mkShellNoCC {


### PR DESCRIPTION
## Summary

- Replace manual localTargets definition with agentLib.defaultLocalTargets
- Override only the structure to use symlink-tree instead of copy-tree  
- Update agent-skills-nix to latest version (2026-02-04)
- Skills now install to both .agents/skills and .claude/skills

## Test plan

- [x] Run `nix develop` and verify skills install to both directories
- [x] Verify skills are symlinked to nix store

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use agentLib.defaultLocalTargets and symlink-tree for skills to simplify setup and symlink to the Nix store. Skills now install to both .agents/skills and .claude/skills, and agent-skills-nix is updated to 2026-02-04.

<sup>Written for commit 768447628b8893d57afee3de701b039085343ad6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

