### PR TITLE
chore(envrc): add watch_file for pnpm-lock.yaml and pnpm-workspace.yaml

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_file pnpm-lock.yaml
+watch_file pnpm-workspace.yaml
 use flake


### PR DESCRIPTION
Adds direnv watch_file entries for pnpm-lock.yaml and pnpm-workspace.yaml so the shell environment reloads when dependencies or workspace security settings change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach direnv to watch pnpm-lock.yaml and pnpm-workspace.yaml so the shell reloads when dependencies or workspace settings change. Keeps the environment in sync with pnpm config (e.g., allowBuilds, strictDepBuilds) without manual reloads.

<sup>Written for commit 7a3e0214dcee656aec17f6252b64a3d3d80c20da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the `.envrc` file to include `watch_file` directives for `pnpm-lock.yaml` and `pnpm-workspace.yaml`. This ensures that the environment is reloaded by `direnv` when changes occur in these PNPM configuration files, improving development workflow.

#### Key Changes
- Added `watch_file pnpm-lock.yaml` to `.envrc`.
- Added `watch_file pnpm-workspace.yaml` to `.envrc`.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 2 (100.0%)    |
| Total Changes | 2           |

#### Linked JIRA Issues
No issues found. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>