### PR TITLE
Add implicit feedback with LangSmith integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,8 +4,10 @@
     "": {
       "name": "stackone-ai-ts",
       "dependencies": {
+        "/tool-feedback": "file:../tool-feedback-node",
         "@orama/orama": "^3.1.11",
         "json-schema": "^0.4.0",
+        "langsmith": "^0.3.69",
       },
       "devDependencies": {
         "@ai-sdk/openai": "^1.1.14",
@@ -32,6 +34,8 @@
     },
   },
   "packages": {
+    "/tool-feedback": ["@stackone/tool-feedback@file:../tool-feedback-node", { "dependencies": { "langsmith": "^0.3.69" } }],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@1.1.14", "", { "dependencies": { "@ai-sdk/provider": "1.0.9", "@ai-sdk/provider-utils": "2.1.10" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-r5oD+Sz7z8kfxnXfqR53fYQ1xbT/BeUGhQ26FWzs5gO4j52pGUpzCt0SBm3SH1ZSjFY5O/zoKRnsbrPeBe1sNA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@1.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA=="],
@@ -160,9 +164,13 @@
 
     "@types/node": ["@types/node@22.13.5", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
@@ -190,7 +198,7 @@
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
-    "ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "ansis": ["ansis@4.1.0", "", {}, "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="],
 
@@ -225,6 +233,8 @@
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
+
+    "console-table-printer": ["console-table-printer@2.14.6", "", { "dependencies": { "simple-wcswidth": "^1.0.1" } }, "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -272,6 +282,8 @@
 
     "graphql": ["graphql@16.11.0", "", {}, "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
@@ -297,6 +309,8 @@
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
+
+    "langsmith": ["langsmith@0.3.69", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "p-retry": "4", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai"] }, "sha512-YKzu92YAP2o+d+1VmR38xqFX0RIRLKYj1IqdflVEY83X0FoiVlrWO3xDLXgnu7vhZ2N2M6jx8VO9fVF8yy9gHA=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -336,6 +350,14 @@
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
+
     "package-manager-detector": ["package-manager-detector@1.3.0", "", {}, "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -374,6 +396,8 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rolldown": ["rolldown@1.0.0-beta.15", "", { "dependencies": { "@oxc-project/runtime": "=0.72.3", "@oxc-project/types": "=0.72.3", "@rolldown/pluginutils": "1.0.0-beta.15", "ansis": "^4.0.0" }, "optionalDependencies": { "@rolldown/binding-darwin-arm64": "1.0.0-beta.15", "@rolldown/binding-darwin-x64": "1.0.0-beta.15", "@rolldown/binding-freebsd-x64": "1.0.0-beta.15", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-beta.15", "@rolldown/binding-linux-arm64-gnu": "1.0.0-beta.15", "@rolldown/binding-linux-arm64-musl": "1.0.0-beta.15", "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.15", "@rolldown/binding-linux-x64-musl": "1.0.0-beta.15", "@rolldown/binding-wasm32-wasi": "1.0.0-beta.15", "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.15", "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.15", "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.15" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ep788NsIGl0W5gT+99hBrSGe4Hdhcwc55PqM3O0mR5H0C4ZpGpDGgu9YzTJ8a6mFDLnFnc/LYC+Dszb7oWK/dg=="],
@@ -392,6 +416,8 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
+
     "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -405,6 +431,8 @@
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "swr": ["swr@2.3.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-RosxFpiabojs75IwQ316DGoDRmOqtiAj0tg8wCcbEu4CiLZBs/a9QNtHV7TUfDXmmlgqij/NqzKq/eLelyv9xA=="],
 
@@ -440,6 +468,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -470,13 +500,19 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "langsmith/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "rolldown-plugin-dts/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
@@ -488,11 +524,11 @@
 
     "unplugin/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
     "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "@inquirer/core/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
-
-    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -500,7 +536,7 @@
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.0.0", "", { "dependencies": { "get-east-asian-width": "^1.0.0" } }, "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "dependencies": {
     "@orama/orama": "^3.1.11",
-    "json-schema": "^0.4.0"
+    "json-schema": "^0.4.0",
+    "langsmith": "^0.3.69",
+    "/tool-feedback": "file:../tool-feedback-node"
   },
   "devDependencies": {
     "@ai-sdk/openai": "^1.1.14",

--- a/scripts/list-all-tools.ts
+++ b/scripts/list-all-tools.ts
@@ -1,0 +1,14 @@
+import { StackOneToolSet } from '../src/toolsets/stackone';
+
+const toolset = new StackOneToolSet();
+const tools = toolset.getStackOneTools();
+
+let count = 0;
+for (const tool of tools) {
+  console.log(tool.name);
+  count += 1;
+  if (count >= 50) {
+    break;
+  }
+}
+console.log('Total tools enumerated (first 50):', count);

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -1,0 +1,162 @@
+import { configureImplicitFeedback, LangsmithFeedbackClient } from '../src/feedback';
+import { StackOneToolSet } from '../src/toolsets/stackone';
+
+async function main() {
+  const sessionId = `hris-feedback-${Date.now()}`;
+
+  // Log when runs are pushed to LangSmith while preserving original behaviour.
+  const originalLangSmithLog = LangsmithFeedbackClient.prototype.logToolCall;
+  LangsmithFeedbackClient.prototype.logToolCall = async function (session, record) {
+    console.log('[langsmith] logging run', { toolName: record.toolName, session });
+    const runId = await originalLangSmithLog.call(this, session, record);
+    console.log('[langsmith] run id', runId ?? 'none');
+    return runId;
+  };
+
+  const manager = configureImplicitFeedback({
+    enabled: true,
+    langsmith: {
+      enabled: true,
+      projectName: process.env.LANGSMITH_PROJECT ?? 'stackone-implicit-feedback',
+    },
+  });
+
+  const maskHeaders = (value: unknown) => {
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+    const clone: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+    if ('Authorization' in clone) {
+      clone.Authorization = '[redacted]';
+    }
+    if ('authorization' in clone) {
+      clone.authorization = '[redacted]';
+    }
+    return clone;
+  };
+
+  const maskRequest = (value: unknown) => {
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+    const clone: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+    if ('headers' in clone) {
+      clone.headers = maskHeaders(clone.headers);
+    }
+    return clone;
+  };
+
+  console.log('[feedback] harness ready', { sessionId });
+  console.log('LangSmith logging is enabled:', manager.isEnabled());
+
+  const originalRecord = manager.recordToolCall.bind(manager);
+  manager.recordToolCall = async (snapshot) => {
+    console.log('[feedback] snapshot', {
+      toolName: snapshot.toolName,
+      success: snapshot.success,
+      error: snapshot.error,
+      startedAt: snapshot.startedAt,
+      completedAt: snapshot.completedAt,
+      executionTimeMs: snapshot.executionTime,
+      sessionId: sessionId,
+      summary: snapshot.resultSummary,
+      context: snapshot.callContext,
+    });
+    return originalRecord(snapshot);
+  };
+
+  const toolset = new StackOneToolSet({ strict: true });
+  const tools = toolset.getStackOneTools();
+
+  const listEmployeesTool = tools.getStackOneTool('hris_list_employees');
+  const getEmploymentTool = tools.getStackOneTool('hris_get_employment');
+
+  console.log('Executing hris_list_employees dry run to inspect request shape...');
+  const listEmployeesDry = await listEmployeesTool.execute({}, {
+    dryRun: true,
+    feedbackSessionId: sessionId,
+  });
+  console.log('Dry run request:', maskRequest(listEmployeesDry));
+
+  console.log('Executing hris_list_employees live call to fetch the actual employee page...');
+  const listEmployeesLive = await listEmployeesTool.execute({}, {
+    feedbackSessionId: sessionId,
+  });
+
+  const employeesPage = Array.isArray((listEmployeesLive as any)?.data)
+    ? (listEmployeesLive as any).data
+    : Array.isArray(listEmployeesLive)
+    ? (listEmployeesLive as any)
+    : [];
+
+  console.log('Employees page length:', employeesPage.length);
+  if (employeesPage.length > 0) {
+    const firstEmployee = employeesPage[0] as Record<string, unknown>;
+    console.log('First employee summary:', {
+      id: firstEmployee.id,
+      name: firstEmployee.name,
+      employmentCount: Array.isArray(firstEmployee.employments)
+        ? firstEmployee.employments.length
+        : undefined,
+    });
+  }
+
+  let employmentId: string | undefined;
+
+  for (const employee of employeesPage) {
+    const employments = (employee as Record<string, any>).employments;
+    if (Array.isArray(employments)) {
+      const match = employments.find((item) => typeof item?.id === 'string' && item.id.length > 0);
+      if (match) {
+        employmentId = match.id;
+        break;
+      }
+    }
+  }
+
+  if (!employmentId) {
+    console.log('No employment id found on employees, retrieving via hris_list_employments to backfill...');
+    const listEmploymentsTool = tools.getStackOneTool('hris_list_employments');
+    const employmentsLive = await listEmploymentsTool.execute({}, { feedbackSessionId: sessionId });
+    const employmentsData = Array.isArray((employmentsLive as any)?.data)
+      ? (employmentsLive as any).data
+      : Array.isArray(employmentsLive)
+      ? (employmentsLive as any)
+      : [];
+    employmentId = employmentsData.find((item: Record<string, unknown>) =>
+      typeof item?.id === 'string'
+    )?.id as string | undefined;
+    console.log('Selected employment id:', employmentId ?? 'none');
+  }
+
+  if (!employmentId) {
+    throw new Error('Unable to determine an employment id to fetch');
+  }
+
+  console.log('Executing hris_get_employment dry run to review the request headers...');
+  const getEmploymentDry = await getEmploymentTool.execute(
+    { id: employmentId },
+    { dryRun: true, feedbackSessionId: sessionId }
+  );
+  console.log('Dry run request:', maskRequest(getEmploymentDry));
+
+  console.log('Executing hris_get_employment live call to inspect a specific employment...');
+  const employment = await getEmploymentTool.execute(
+    { id: employmentId },
+    { feedbackSessionId: sessionId }
+  );
+
+  console.log('Employment summary:', {
+    id: (employment as any)?.data?.id ?? (employment as any)?.id,
+    employeeId: (employment as any)?.data?.employee_id ?? (employment as any)?.employee_id,
+    jobTitle: (employment as any)?.data?.job_title ?? (employment as any)?.job_title,
+    effectiveDate: (employment as any)?.data?.effective_date ?? (employment as any)?.effective_date,
+  });
+
+  configureImplicitFeedback({ enabled: false, langsmith: { enabled: false } });
+}
+
+main().catch((error) => {
+  console.error('Failed to execute tool:', error);
+  process.exitCode = 1;
+});

--- a/scripts/tool-info.ts
+++ b/scripts/tool-info.ts
@@ -1,0 +1,5 @@
+import { StackOneToolSet } from '../src/toolsets/stackone';
+
+const toolset = new StackOneToolSet();
+const tool = toolset.getStackOneTools('ats_list_applications').getStackOneTool('ats_list_applications');
+console.dir(tool.parameters, { depth: 5 });

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -1,0 +1,19 @@
+export {
+  configureImplicitFeedback,
+  getImplicitFeedbackManager,
+  ImplicitFeedbackManager,
+  LangsmithFeedbackClient,
+} from '@stackone/tool-feedback';
+export type {
+  ImplicitFeedbackConfig,
+  LangSmithConfig,
+  ResultSummary,
+  ToolCallRecord,
+  ToolExecutionSnapshot,
+  ToolFeedback,
+} from '@stackone/tool-feedback';
+export {
+  buildResultInsights,
+  buildErrorSummary,
+  extractQuery,
+} from '@stackone/tool-feedback';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,20 @@ export { BaseTool, StackOneTool, Tools } from './tool';
 export { StackOneAPIError, StackOneError } from './utils/errors';
 
 export {
+  ImplicitFeedbackManager,
+  configureImplicitFeedback,
+  getImplicitFeedbackManager,
+} from './feedback';
+
+export type {
+  ImplicitFeedbackConfig,
+  LangSmithConfig,
+  ResultSummary,
+  ToolCallRecord,
+  ToolExecutionSnapshot,
+} from './feedback';
+
+export {
   OpenAPIToolSet,
   StackOneToolSet,
   ToolSetConfigError,

--- a/src/tests/feedback-manager.spec.ts
+++ b/src/tests/feedback-manager.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { configureImplicitFeedback } from '../feedback';
+import { StackOneTool } from '../tool';
+import { StackOneToolSet } from '../toolsets';
+
+function requireApiKey(): string {
+  const apiKey = process.env.STACKONE_API_KEY;
+  if (!apiKey) {
+    throw new Error('STACKONE_API_KEY must be set for feedback integration tests');
+  }
+  return apiKey;
+}
+
+function findToolWithoutRequiredParams(): StackOneTool {
+  const toolset = new StackOneToolSet();
+  const tools = toolset.getStackOneTools();
+
+  for (const tool of tools) {
+    const required = tool.parameters.required ?? [];
+    if (required.length === 0 && tool instanceof StackOneTool) {
+      return tool;
+    }
+  }
+
+  throw new Error('Expected at least one StackOne tool without required parameters');
+}
+
+describe('Implicit feedback integration', () => {
+  const apiKey = requireApiKey();
+  const tool = findToolWithoutRequiredParams();
+
+  afterEach(() => {
+    configureImplicitFeedback({ enabled: false, langsmith: { enabled: false } });
+  });
+
+  it('records tool execution snapshots when feedback is enabled', async () => {
+    const manager = configureImplicitFeedback({ enabled: true, langsmith: { enabled: false } });
+    const recordSpy = spyOn(manager, 'recordToolCall');
+
+    const result = await tool.execute({}, { dryRun: true });
+
+    const expectedAuth = `Basic ${Buffer.from(`${apiKey}:`).toString('base64')}`;
+    expect(result.headers.Authorization).toBe(expectedAuth);
+
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    const snapshot = recordSpy.mock.calls[0][0];
+    expect(snapshot.toolName).toBe(tool.name);
+    expect(snapshot.parameters).toEqual({});
+    expect(snapshot.success).toBe(true);
+    expect(snapshot.rawResult).toEqual(result);
+    expect(snapshot.callContext.query).toBeUndefined();
+
+    recordSpy.mockRestore();
+  });
+
+  it('does not record execution when feedback is disabled', async () => {
+    const manager = configureImplicitFeedback({ enabled: false, langsmith: { enabled: false } });
+    const recordSpy = spyOn(manager, 'recordToolCall');
+
+    await tool.execute({}, { dryRun: true });
+
+    expect(manager.isEnabled()).toBe(false);
+    expect(recordSpy).not.toHaveBeenCalled();
+
+    recordSpy.mockRestore();
+  });
+});

--- a/src/toolsets/tests/stackone.spec.ts
+++ b/src/toolsets/tests/stackone.spec.ts
@@ -5,6 +5,7 @@ import { StackOneToolSet } from '../stackone';
 
 // Mock environment variables
 env.STACKONE_API_KEY = 'test_key';
+env.STACKONE_ACCOUNT_ID = undefined;
 
 describe('StackOneToolSet', () => {
   // Snapshot tests

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,10 @@ export interface ExecuteOptions {
    * Useful for debugging and testing transformed parameters
    */
   dryRun?: boolean;
+  /**
+   * Optional session identifier used by the implicit feedback system to correlate tool calls
+   */
+  feedbackSessionId?: string;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     /* Build for a library */
     "module": "ESNext",
     "moduleResolution": "node",
+    "baseUrl": ".",
     "outDir": "dist",
     "sourceMap": true,
     "declaration": true,
@@ -24,7 +25,13 @@
     /* Other */
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2022"],
-    "types": ["bun-types"]
+    "types": ["bun-types"],
+    "paths": {
+      "@stackone/tool-feedback": ["../tool-feedback-node/src/index.ts"],
+      "@stackone/tool-feedback/*": ["../tool-feedback-node/src/*"],
+      "langsmith": ["./node_modules/langsmith/dist/index.d.ts"],
+      "langsmith/*": ["./node_modules/langsmith/dist/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts"]


### PR DESCRIPTION
Reviewed by benchmark automation.

This pull request introduces implicit feedback functionality with LangSmith integration.

## Changes
- Added feedback management system
- Integrated LangSmith feedback tracking
- Added tool execution scripts (list-all-tools, run-tool, tool-info)
- Enhanced tool system with feedback capabilities
- Added comprehensive tests for feedback functionality

## Files Changed
- New: `src/feedback/index.ts` - Feedback management module
- New: `src/tests/feedback-manager.spec.ts` - Feedback tests
- New: `scripts/` - Tool management scripts
- Modified: `src/tool.ts`, `src/index.ts`, `package.json`, and configuration files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds implicit feedback collection for every tool execution with LangSmith integration, enabling structured run analytics without extra user prompts. Also adds utility scripts and exposes feedback APIs, plus a `feedbackSessionId` for correlating calls.

- **New Features**
  - Tool executions now record snapshots via `ImplicitFeedbackManager` and can auto-log to LangSmith when credentials are set or via `configureImplicitFeedback`.
  - Added `feedbackSessionId` to `ExecuteOptions` for conversation-level correlation.
  - Exposed feedback APIs/types via `src/feedback` and re-exported from the package entry.
  - New scripts: `scripts/run-tool.ts` (demo end-to-end with LangSmith), `scripts/list-all-tools.ts`, `scripts/tool-info.ts`. Added tests for feedback behavior.

- **Dependencies**
  - Added `langsmith` runtime dependency.
  - Linked local `@stackone/tool-feedback` (via `/tool-feedback` file reference and TS path mapping) until the package is published.

<sup>Written for commit cdd3de168fd4f686c2b99aa62c0b0984d8e1022d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

