### PR TITLE
feat(search-optimization): cache fetchTools results and ToolIndex across calls

### DIFF
--- a/examples/benchmark-search.ts
+++ b/examples/benchmark-search.ts
@@ -1,0 +1,113 @@
+/**
+ * Benchmark: measure SDK search latency with caching.
+ *
+ * Runs fetchTools, local (BM25+TF-IDF) search, and semantic search N times,
+ * reports cold vs warm average latency and the speedup from caching.
+ *
+ * Prerequisites:
+ *   - STACKONE_API_KEY environment variable
+ *   - STACKONE_ACCOUNT_ID environment variable
+ *
+ * Run with:
+ *   STACKONE_API_KEY=xxx STACKONE_ACCOUNT_ID=xxx npx tsx examples/benchmark-search.ts
+ *   STACKONE_API_KEY=xxx STACKONE_ACCOUNT_ID=xxx npx tsx examples/benchmark-search.ts --iterations 50
+ */
+
+import process from 'node:process';
+import { StackOneToolSet } from '@stackone/ai';
+
+const QUERIES = ['list events', 'cancel a meeting', 'send a message', 'get current user', 'list employees'];
+
+function parseArgs(): number {
+	const idx = process.argv.indexOf('--iterations');
+	const idxShort = process.argv.indexOf('-n');
+	const pos = idx !== -1 ? idx : idxShort;
+	if (pos !== -1 && process.argv[pos + 1]) {
+		return Number.parseInt(process.argv[pos + 1], 10);
+	}
+	return 100;
+}
+
+async function bench(fn: () => Promise<void>, n: number): Promise<{ cold: number; warmAvg: number }> {
+	const times: number[] = [];
+	for (let i = 0; i < n; i++) {
+		const start = performance.now();
+		await fn();
+		times.push(performance.now() - start);
+	}
+	const cold = times[0];
+	const warmTimes = times.slice(1);
+	const warmAvg = warmTimes.length > 0 ? warmTimes.reduce((a, b) => a + b, 0) / warmTimes.length : cold;
+	return { cold, warmAvg };
+}
+
+function fmtMs(ms: number): string {
+	return `${ms.toFixed(1)}ms`.padStart(10);
+}
+
+async function main(): Promise<void> {
+	const iterations = parseArgs();
+
+	const apiKey = process.env.STACKONE_API_KEY;
+	const accountId = process.env.STACKONE_ACCOUNT_ID;
+
+	if (!apiKey) {
+		console.error('Set STACKONE_API_KEY to run this benchmark.');
+		process.exit(1);
+	}
+	if (!accountId) {
+		console.error('Set STACKONE_ACCOUNT_ID to run this benchmark.');
+		process.exit(1);
+	}
+
+	console.log(`Benchmarking with account ${accountId.slice(0, 8)}..., ${iterations} iterations each\n`);
+
+	const ts = new StackOneToolSet({
+		apiKey,
+		accountId,
+		search: { method: 'auto', topK: 5 },
+	});
+
+	const results: Array<{ name: string; cold: number; warmAvg: number; speedup: number }> = [];
+	let queryIdx = 0;
+	const nextQuery = (): string => QUERIES[queryIdx++ % QUERIES.length];
+
+	// --- 1. fetchTools ---
+	console.log(`[1/3] fetchTools x${iterations} ...`);
+	ts.clearCatalogCache();
+	const fetch = await bench(() => ts.fetchTools(), iterations);
+	const fetchSpeedup = fetch.cold / fetch.warmAvg;
+	results.push({ name: 'fetchTools', ...fetch, speedup: fetchSpeedup });
+	console.log(`       cold=${fmtMs(fetch.cold)}  warm_avg=${fmtMs(fetch.warmAvg)}  speedup=${fetchSpeedup.toFixed(0)}x`);
+
+	// --- 2. local search (BM25 + TF-IDF) ---
+	console.log(`[2/3] searchTools (local) x${iterations} ...`);
+	ts.clearCatalogCache();
+	queryIdx = 0;
+	const local = await bench(() => ts.searchTools(nextQuery(), { search: 'local' }), iterations);
+	const localSpeedup = local.cold / local.warmAvg;
+	results.push({ name: 'search (local/BM25)', ...local, speedup: localSpeedup });
+	console.log(`       cold=${fmtMs(local.cold)}  warm_avg=${fmtMs(local.warmAvg)}  speedup=${localSpeedup.toFixed(0)}x`);
+
+	// --- 3. semantic search (auto) ---
+	console.log(`[3/3] searchTools (semantic/auto) x${iterations} ...`);
+	ts.clearCatalogCache();
+	queryIdx = 0;
+	const semantic = await bench(() => ts.searchTools(nextQuery(), { search: 'auto' }), iterations);
+	const semanticSpeedup = semantic.cold / semantic.warmAvg;
+	results.push({ name: 'search (semantic)', ...semantic, speedup: semanticSpeedup });
+	console.log(`       cold=${fmtMs(semantic.cold)}  warm_avg=${fmtMs(semantic.warmAvg)}  speedup=${semanticSpeedup.toFixed(0)}x`);
+
+	// --- Summary ---
+	console.log('\n' + '='.repeat(65));
+	console.log(`${'Benchmark'.padEnd(22)} ${'Cold'.padStart(10)} ${'Warm (avg)'.padStart(10)} ${'Speedup'.padStart(10)}`);
+	console.log('-'.repeat(65));
+	for (const r of results) {
+		console.log(`${r.name.padEnd(22)} ${fmtMs(r.cold)} ${fmtMs(r.warmAvg)} ${`${r.speedup.toFixed(0)}x`.padStart(10)}`);
+	}
+	console.log('='.repeat(65));
+	console.log(`\nWarm = average of ${iterations - 1} calls after the first (cold) call.`);
+	console.log('Speedup = cold / warm_avg — shows the benefit of caching.\n');
+}
+
+main();

--- a/examples/benchmark-search.ts
+++ b/examples/benchmark-search.ts
@@ -35,7 +35,7 @@ function parseArgs(): number {
 }
 
 async function bench(
-	fn: () => Promise<void>,
+	fn: () => Promise<unknown>,
 	n: number,
 ): Promise<{ cold: number; warmAvg: number }> {
 	const times: number[] = [];
@@ -132,4 +132,4 @@ async function main(): Promise<void> {
 	console.log('Speedup = cold / warm_avg — shows the benefit of caching.\n');
 }
 
-main();
+void main();

--- a/examples/benchmark-search.ts
+++ b/examples/benchmark-search.ts
@@ -16,7 +16,13 @@
 import process from 'node:process';
 import { StackOneToolSet } from '@stackone/ai';
 
-const QUERIES = ['list events', 'cancel a meeting', 'send a message', 'get current user', 'list employees'];
+const QUERIES = [
+	'list events',
+	'cancel a meeting',
+	'send a message',
+	'get current user',
+	'list employees',
+];
 
 function parseArgs(): number {
 	const idx = process.argv.indexOf('--iterations');
@@ -28,7 +34,10 @@ function parseArgs(): number {
 	return 100;
 }
 
-async function bench(fn: () => Promise<void>, n: number): Promise<{ cold: number; warmAvg: number }> {
+async function bench(
+	fn: () => Promise<void>,
+	n: number,
+): Promise<{ cold: number; warmAvg: number }> {
 	const times: number[] = [];
 	for (let i = 0; i < n; i++) {
 		const start = performance.now();
@@ -37,7 +46,8 @@ async function bench(fn: () => Promise<void>, n: number): Promise<{ cold: number
 	}
 	const cold = times[0];
 	const warmTimes = times.slice(1);
-	const warmAvg = warmTimes.length > 0 ? warmTimes.reduce((a, b) => a + b, 0) / warmTimes.length : cold;
+	const warmAvg =
+		warmTimes.length > 0 ? warmTimes.reduce((a, b) => a + b, 0) / warmTimes.length : cold;
 	return { cold, warmAvg };
 }
 
@@ -60,7 +70,9 @@ async function main(): Promise<void> {
 		process.exit(1);
 	}
 
-	console.log(`Benchmarking with account ${accountId.slice(0, 8)}..., ${iterations} iterations each\n`);
+	console.log(
+		`Benchmarking with account ${accountId.slice(0, 8)}..., ${iterations} iterations each\n`,
+	);
 
 	const ts = new StackOneToolSet({
 		apiKey,
@@ -78,7 +90,9 @@ async function main(): Promise<void> {
 	const fetch = await bench(() => ts.fetchTools(), iterations);
 	const fetchSpeedup = fetch.cold / fetch.warmAvg;
 	results.push({ name: 'fetchTools', ...fetch, speedup: fetchSpeedup });
-	console.log(`       cold=${fmtMs(fetch.cold)}  warm_avg=${fmtMs(fetch.warmAvg)}  speedup=${fetchSpeedup.toFixed(0)}x`);
+	console.log(
+		`       cold=${fmtMs(fetch.cold)}  warm_avg=${fmtMs(fetch.warmAvg)}  speedup=${fetchSpeedup.toFixed(0)}x`,
+	);
 
 	// --- 2. local search (BM25 + TF-IDF) ---
 	console.log(`[2/3] searchTools (local) x${iterations} ...`);
@@ -87,7 +101,9 @@ async function main(): Promise<void> {
 	const local = await bench(() => ts.searchTools(nextQuery(), { search: 'local' }), iterations);
 	const localSpeedup = local.cold / local.warmAvg;
 	results.push({ name: 'search (local/BM25)', ...local, speedup: localSpeedup });
-	console.log(`       cold=${fmtMs(local.cold)}  warm_avg=${fmtMs(local.warmAvg)}  speedup=${localSpeedup.toFixed(0)}x`);
+	console.log(
+		`       cold=${fmtMs(local.cold)}  warm_avg=${fmtMs(local.warmAvg)}  speedup=${localSpeedup.toFixed(0)}x`,
+	);
 
 	// --- 3. semantic search (auto) ---
 	console.log(`[3/3] searchTools (semantic/auto) x${iterations} ...`);
@@ -96,14 +112,20 @@ async function main(): Promise<void> {
 	const semantic = await bench(() => ts.searchTools(nextQuery(), { search: 'auto' }), iterations);
 	const semanticSpeedup = semantic.cold / semantic.warmAvg;
 	results.push({ name: 'search (semantic)', ...semantic, speedup: semanticSpeedup });
-	console.log(`       cold=${fmtMs(semantic.cold)}  warm_avg=${fmtMs(semantic.warmAvg)}  speedup=${semanticSpeedup.toFixed(0)}x`);
+	console.log(
+		`       cold=${fmtMs(semantic.cold)}  warm_avg=${fmtMs(semantic.warmAvg)}  speedup=${semanticSpeedup.toFixed(0)}x`,
+	);
 
 	// --- Summary ---
 	console.log('\n' + '='.repeat(65));
-	console.log(`${'Benchmark'.padEnd(22)} ${'Cold'.padStart(10)} ${'Warm (avg)'.padStart(10)} ${'Speedup'.padStart(10)}`);
+	console.log(
+		`${'Benchmark'.padEnd(22)} ${'Cold'.padStart(10)} ${'Warm (avg)'.padStart(10)} ${'Speedup'.padStart(10)}`,
+	);
 	console.log('-'.repeat(65));
 	for (const r of results) {
-		console.log(`${r.name.padEnd(22)} ${fmtMs(r.cold)} ${fmtMs(r.warmAvg)} ${`${r.speedup.toFixed(0)}x`.padStart(10)}`);
+		console.log(
+			`${r.name.padEnd(22)} ${fmtMs(r.cold)} ${fmtMs(r.warmAvg)} ${`${r.speedup.toFixed(0)}x`.padStart(10)}`,
+		);
 	}
 	console.log('='.repeat(65));
 	console.log(`\nWarm = average of ${iterations - 1} calls after the first (cold) call.`);

--- a/src/toolsets.test.ts
+++ b/src/toolsets.test.ts
@@ -1014,4 +1014,135 @@ describe('StackOneToolSet', () => {
 			expect(tools.length).toBeGreaterThan(0);
 		});
 	});
+
+	describe('catalog cache', () => {
+		const installMcpSpy = (
+			accountTools: Record<string, McpToolDefinition[]> = {
+				acc1: [
+					{
+						name: 'acc1_tool_1',
+						description: 'acc1 tool 1',
+						inputSchema: { type: 'object', properties: {} },
+					},
+				],
+				acc2: [
+					{
+						name: 'acc2_tool_1',
+						description: 'acc2 tool 1',
+						inputSchema: { type: 'object', properties: {} },
+					},
+				],
+			},
+		) => {
+			const testMcpApp = createMcpApp({ accountTools });
+			const counter = { count: 0 };
+			server.use(
+				http.all(`${TEST_BASE_URL}/mcp`, async ({ request }) => {
+					counter.count += 1;
+					return testMcpApp.fetch(request);
+				}),
+			);
+			return counter;
+		};
+
+		it('memoizes fetchTools results across repeat calls', async () => {
+			const counter = installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			const afterFirst = counter.count;
+			expect(afterFirst).toBeGreaterThan(0);
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			expect(counter.count).toBe(afterFirst);
+		});
+
+		it('uses separate cache entries for different account sets', async () => {
+			const counter = installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			const afterAcc1 = counter.count;
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			expect(counter.count).toBe(afterAcc1);
+
+			await toolset.fetchTools({ accountIds: ['acc2'] });
+			expect(counter.count).toBeGreaterThan(afterAcc1);
+			const afterAcc2 = counter.count;
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			expect(counter.count).toBe(afterAcc2);
+		});
+
+		it('account-id ordering does not affect cache hits', async () => {
+			const counter = installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			await toolset.fetchTools({ accountIds: ['acc1', 'acc2'] });
+			const afterFirst = counter.count;
+			expect(afterFirst).toBeGreaterThan(0);
+
+			// Reordered list should hit the cache — no new MCP traffic.
+			await toolset.fetchTools({ accountIds: ['acc2', 'acc1'] });
+			expect(counter.count).toBe(afterFirst);
+		});
+
+		it('clearCatalogCache forces a refetch', async () => {
+			const counter = installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			const afterFirst = counter.count;
+
+			toolset.clearCatalogCache();
+			await toolset.fetchTools({ accountIds: ['acc1'] });
+			expect(counter.count).toBeGreaterThan(afterFirst);
+		});
+
+		it('setAccounts invalidates the cache', async () => {
+			const counter = installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountIds: ['acc1'],
+			});
+
+			await toolset.fetchTools();
+			await toolset.fetchTools();
+			const afterAcc1 = counter.count;
+
+			toolset.setAccounts(['acc2']);
+			await toolset.fetchTools();
+			expect(counter.count).toBeGreaterThan(afterAcc1);
+		});
+
+		it('reuses the same Tools instance on cache hit (identity)', async () => {
+			installMcpSpy();
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			const first = await toolset.fetchTools({ accountIds: ['acc1'] });
+			const second = await toolset.fetchTools({ accountIds: ['acc1'] });
+
+			// Identity reuse means the toolIndex cache's reference-equality check
+			// in localSearch can hit across search calls.
+			expect(second).toBe(first);
+		});
+	});
 });

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -557,6 +557,8 @@ export class StackOneToolSet {
 	}
 
 	private semanticSearchClient?: SemanticSearchClient;
+	private catalogCache: Map<string, Tools> = new Map();
+	private toolIndexCache?: { tools: Tools; index: ToolIndex };
 
 	/**
 	 * Set account IDs for filtering tools
@@ -565,7 +567,19 @@ export class StackOneToolSet {
 	 */
 	setAccounts(accountIds: string[]): this {
 		this.accountIds = accountIds;
+		this.clearCatalogCache();
 		return this;
+	}
+
+	/**
+	 * Invalidate cached tool catalog and local search index.
+	 *
+	 * Call when linked accounts change outside of {@link setAccounts} or when
+	 * you need to force a fresh fetch from the StackOne MCP endpoint.
+	 */
+	clearCatalogCache(): void {
+		this.catalogCache.clear();
+		this.toolIndexCache = undefined;
 	}
 
 	/**
@@ -999,7 +1013,10 @@ export class StackOneToolSet {
 			return new Tools([]);
 		}
 
-		const index = new ToolIndex(allTools.toArray());
+		if (!this.toolIndexCache || this.toolIndexCache.tools !== allTools) {
+			this.toolIndexCache = { tools: allTools, index: new ToolIndex(allTools.toArray()) };
+		}
+		const index = this.toolIndexCache.index;
 		const results = await index.search(query, options?.topK ?? 5, options?.minSimilarity ?? 0.0);
 
 		const matchedNames = results.map((r) => r.name);
@@ -1024,6 +1041,16 @@ export class StackOneToolSet {
 	async fetchTools(options?: FetchToolsOptions): Promise<Tools> {
 		// Use account IDs from options, or fall back to instance state
 		const effectiveAccountIds = options?.accountIds || this.accountIds;
+
+		const cacheKey = JSON.stringify({
+			accountIds: [...effectiveAccountIds].sort(),
+			providers: options?.providers ? [...options.providers].sort() : null,
+			actions: options?.actions ? [...options.actions].sort() : null,
+		});
+		const cached = this.catalogCache.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
 
 		// Fetch tools (with account filtering if needed)
 		let tools: Tools;
@@ -1061,6 +1088,7 @@ export class StackOneToolSet {
 		const feedbackTool = createFeedbackTool(undefined, this.accountId, this.baseUrl);
 		const toolsWithFeedback = new Tools([...filteredTools.toArray(), feedbackTool]);
 
+		this.catalogCache.set(cacheKey, toolsWithFeedback);
 		return toolsWithFeedback;
 	}
 

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -1044,8 +1044,8 @@ export class StackOneToolSet {
 
 		const cacheKey = JSON.stringify({
 			accountIds: [...effectiveAccountIds].sort(),
-			providers: options?.providers ? [...options.providers].sort() : null,
-			actions: options?.actions ? [...options.actions].sort() : null,
+			providers: options?.providers?.length ? [...options.providers].sort() : null,
+			actions: options?.actions?.length ? [...options.actions].sort() : null,
 		});
 		const cached = this.catalogCache.get(cacheKey);
 		if (cached) {


### PR DESCRIPTION
## Problem

  `searchTools` latency in agent loops scaled linearly with the number of linked accounts because:

  1. **`searchTools()` unconditionally called `fetchTools()`** with no cache on the search path.
  2. **`ToolIndex` (BM25 + TF-IDF) was reconstructed on every local-search fallback call** — no caching.

  Node already parallelizes per-account fetches via `Promise.all` (unlike Python), so cold-start here was
  never as bad  but every subsequent call still paid the full cost from scratch.

  ## Fix

  Internal memoization only  no public API signature changes, no behavioral changes in the happy path.

  - **Catalog cache:** `StackOneToolSet.catalogCache: Map<string, Tools>` memoizes `fetchTools()` results
  keyed by a stable serialization of `{ accountIds: sorted, providers: sorted, actions: sorted }`. Account-id
  ordering doesn't affect cache hits.
  - **ToolIndex cache:** reference-keyed on the cached `Tools` instance; rebuilt only when the underlying
  catalog changes.
  - **New public method:** `clearCatalogCache()` for users rotating accounts mid-session.
  - **Invalidation:** `setAccounts()` now calls `clearCatalogCache()` automatically.

  The per-account `Promise.all` fan-out in `fetchTools` is unchanged — it was already correct.

  ## Expected latency change

  - Warm `searchTools` / `fetchTools` / `openai()` / `anthropic()` etc.: now near-instant on repeat calls
  (cache hit).
  - Cold calls: unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache `fetchTools` results and the local `ToolIndex` to eliminate repeat work in `searchTools`, making warm searches near-instant. Adds `examples/benchmark-search.ts` to compare cold vs warm latency and show the speedup; addresses Linear ENG-12639.

- **Performance**
  - Memoize tool catalogs in `StackOneToolSet` keyed by sorted `{accountIds, providers, actions}`.
  - Cache `ToolIndex` per `Tools` instance and return the same `Tools` on cache hits to enable index reuse.
  - Existing per-account parallel fetch logic is unchanged.

- **New Features**
  - `clearCatalogCache()` to force a refetch; also clears the local search index.
  - `setAccounts()` now clears caches automatically.

<sup>Written for commit 35b05c084a41df82470ca51d6431cf65d7f3c492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

