### PR TITLE
fix(toolsets): prevent x-account-id leak across concurrent fetchTools

### DIFF
--- a/src/toolsets.test.ts
+++ b/src/toolsets.test.ts
@@ -383,6 +383,53 @@ describe('StackOneToolSet', () => {
 			expect(toolNames).toContain('acc3_tool_1');
 			expect(toolNames).toContain('tool_feedback');
 		});
+
+		// Regression for issue #365: tools must carry the x-account-id of the
+		// account they were fetched for, even when accounts are fetched
+		// concurrently. The prior implementation mutated this.headers around
+		// async boundaries, so concurrent fetches clobbered each other and
+		// tools were stamped with the wrong account.
+		it('stamps each tool with the x-account-id of its own account under intra-call concurrency', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			const tools = await toolset.fetchTools({ accountIds: ['acc1', 'acc2', 'acc3'] });
+
+			for (const tool of tools.toArray()) {
+				if (tool.name.startsWith('acc1_')) {
+					expect(tool.getHeaders()['x-account-id']).toBe('acc1');
+				} else if (tool.name.startsWith('acc2_')) {
+					expect(tool.getHeaders()['x-account-id']).toBe('acc2');
+				} else if (tool.name.startsWith('acc3_')) {
+					expect(tool.getHeaders()['x-account-id']).toBe('acc3');
+				}
+			}
+		});
+
+		it('stamps tools correctly when two fetchTools calls run concurrently on the same instance', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+			});
+
+			const [acc1Tools, acc2Tools] = await Promise.all([
+				toolset.fetchTools({ accountIds: ['acc1'] }),
+				toolset.fetchTools({ accountIds: ['acc2'] }),
+			]);
+
+			for (const tool of acc1Tools.toArray()) {
+				if (tool.name.startsWith('acc')) {
+					expect(tool.getHeaders()['x-account-id']).toBe('acc1');
+				}
+			}
+			for (const tool of acc2Tools.toArray()) {
+				if (tool.name.startsWith('acc')) {
+					expect(tool.getHeaders()['x-account-id']).toBe('acc2');
+				}
+			}
+		});
 	});
 
 	describe('tool execution', () => {

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -1053,24 +1053,14 @@ export class StackOneToolSet {
 		}
 
 		// Fetch tools (with account filtering if needed)
+		// Headers are threaded as parameters per request — never mutate this.headers,
+		// since concurrent callers would clobber each other's x-account-id.
 		let tools: Tools;
 		if (effectiveAccountIds.length > 0) {
 			const toolsPromises = effectiveAccountIds.map(async (accountId) => {
-				const headers = { 'x-account-id': accountId };
-				const mergedHeaders = { ...this.headers, ...headers };
-
-				// Create a temporary toolset instance with the account-specific headers
-				const tempHeaders = mergedHeaders;
-				const originalHeaders = this.headers;
-				this.headers = tempHeaders;
-
-				try {
-					const tools = await this.fetchToolsFromMcp();
-					return tools.toArray();
-				} finally {
-					// Restore original headers
-					this.headers = originalHeaders;
-				}
+				const requestHeaders = { ...this.headers, 'x-account-id': accountId };
+				const accountTools = await this.fetchToolsFromMcp(requestHeaders);
+				return accountTools.toArray();
 			});
 
 			const toolArrays = await Promise.all(toolsPromises);
@@ -1078,7 +1068,7 @@ export class StackOneToolSet {
 			tools = new Tools(allTools);
 		} else {
 			// No account filtering - fetch all tools
-			tools = await this.fetchToolsFromMcp();
+			tools = await this.fetchToolsFromMcp(this.headers);
 		}
 
 		// Apply provider and action filters
@@ -1093,16 +1083,18 @@ export class StackOneToolSet {
 	}
 
 	/**
-	 * Fetch tool definitions from MCP
+	 * Fetch tool definitions from MCP using the given request headers.
+	 * Headers are passed in (not read from this.headers) so concurrent callers
+	 * can each scope their request to a different x-account-id safely.
 	 */
-	private async fetchToolsFromMcp(): Promise<Tools> {
+	private async fetchToolsFromMcp(requestHeaders: Record<string, string>): Promise<Tools> {
 		if (!this.baseUrl) {
 			throw new ToolSetConfigError('baseUrl is required to fetch MCP tools');
 		}
 
 		await using clients = await createMCPClient({
 			baseUrl: `${this.baseUrl}/mcp`,
-			headers: this.headers,
+			headers: requestHeaders,
 		});
 
 		await clients.client.connect(clients.transport);
@@ -1115,6 +1107,7 @@ export class StackOneToolSet {
 				name,
 				description,
 				inputSchema,
+				headers: requestHeaders,
 			});
 		});
 
@@ -1204,11 +1197,13 @@ export class StackOneToolSet {
 		name,
 		description,
 		inputSchema,
+		headers,
 	}: {
 		actionsClient: RpcClient;
 		name: string;
 		description?: string;
 		inputSchema: ToolInputSchema;
+		headers: Record<string, string>;
 	}): BaseTool {
 		const executeConfig = {
 			kind: 'rpc',
@@ -1235,7 +1230,7 @@ export class StackOneToolSet {
 			description ?? '',
 			toolParameters,
 			executeConfig,
-			this.headers,
+			headers,
 		).setExposeExecutionMetadata(false);
 
 		tool.execute = async (


### PR DESCRIPTION
## Summary

`fetchTools()` mutated `this.headers` to inject the per-account `x-account-id`, then awaited the MCP fetch. Under concurrency  `Promise.all` over multiple `accountIds`, or two `fetchTools()` calls on one instance  those mutations interleaved. `createRpcBackedTool` re-read `this.headers` after the await and baked the **wrong tenant's `x-account-id`** into the returned tools. For a shared `StackOneToolSet` serving multiple users, this is a cross-tenant data-leak path.

Closes #365

## Fix

Stop mutating `this.headers`; thread per-request headers through as a parameter into `fetchToolsFromMcp` → `createRpcBackedTool` → `BaseTool`. `this.headers` is now invariant after construction, so concurrent callers cannot interfere.

```ts
const toolsPromises = effectiveAccountIds.map(async (accountId) => {
    const requestHeaders = { ...this.headers, 'x-account-id': accountId };
    const accountTools = await this.fetchToolsFromMcp(requestHeaders);
    return accountTools.toArray();
});
```

Mirrors the design already used in the Python SDK (`stackone_ai/toolset.py:_fetch_for_account`). The `catalogCache` is fixed transitively.


## Test plan

- [x] `pnpm vitest run src/toolsets.test.ts`  55/55 pass (53 existing + 2 new)
- [x] `pnpm vitest run`  559/559 pass, no regressions
- [ ] `pnpm lint`  run locally in nix dev shell

Both new tests fail deterministically against the buggy code and pass with the fix.

## Out of scope

- **Python SDK**  already correct (zero `self.headers` references in `toolset.py`); no changes needed.
- **Public API** `fetchTools` signature unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cross-tenant header leak in concurrent `fetchTools` calls by passing per-request `x-account-id` headers instead of mutating instance headers. Tools now always carry the correct account scope, preventing data leakage in shared `StackOneToolSet` instances.

- **Bug Fixes**
  - Pass request-scoped headers to `fetchToolsFromMcp` and into tool creation; `this.headers` is no longer mutated.
  - Ensure each tool is stamped with the correct `x-account-id` under intra-call and inter-call concurrency.
  - Added regression tests; public API remains unchanged.

<sup>Written for commit e7ed38bc8473b08cef9ba13c315fc0b2cdba4afd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

