### PR TITLE
fix(tools): handle binary file downloads in tool execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,13 +498,13 @@ if (isBinaryDownloadResult(result)) {
 
 The download result (typed `BinaryDownloadResult`) contains:
 
-- `content`: `Buffer` — the raw file bytes (not JSON-serializable; see note)
+- `content`: `Buffer` — the raw file bytes (not a `JsonValue`; see note)
 - `contentType`: `string` — the file's MIME type (e.g. `application/pdf`), or `application/octet-stream`
 - `statusCode`: `number` — HTTP status of the download response
 - `headers`: `Record<string, string>` — the response headers
 - `fileName`: `string | null` — filename from `Content-Disposition` (RFC 5987 `filename*` aware), or `null`
 
-> **Note:** `content` holds raw bytes and is not JSON-serializable. If you forward tool results to an LLM (or anything that re-serializes to JSON), handle or strip the `content` key — for example, base64-encode it on the LLM-facing path.
+> **Note:** `content` is a raw `Buffer`, not a `JsonValue`. `JSON.stringify` turns it into a `{ type: 'Buffer', data: [...] }` byte array (not the file, and potentially huge), so if you forward tool results to an LLM — or anything that re-serializes to JSON — strip or transform the `content` key first (for example, base64-encode it on the LLM-facing path).
 
 ### Feedback Collection Tool
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,38 @@ The `dryRun` option returns an object containing:
 - `body`: The request body
 - `mappedParams`: The parameters after mapping and derivation
 
+### File Downloads
+
+Actions that download a file (for example `googledrive_unified_download_file`, `documents_download_file`, or any `*_unified_download_file`) return raw bytes plus metadata instead of parsed JSON. The SDK decides from the response `Content-Type`: JSON media types (`application/json` and `+json` suffixes) are parsed as usual, and anything else is treated as a file download.
+
+Use the exported `isBinaryDownloadResult` type guard to narrow the result — no casts needed:
+
+```typescript
+import { writeFileSync } from 'node:fs';
+import { isBinaryDownloadResult, StackOneToolSet } from '@stackone/ai';
+
+const toolset = new StackOneToolSet();
+const tools = await toolset.fetchTools({ actions: ['googledrive_*'] });
+const download = tools.getTool('googledrive_unified_download_file');
+
+const result = await download.execute({ id: 'file-id' });
+
+if (isBinaryDownloadResult(result)) {
+	// result.content is a Buffer; result.fileName is string | null
+	writeFileSync(result.fileName ?? 'download.bin', result.content);
+}
+```
+
+The download result (typed `BinaryDownloadResult`) contains:
+
+- `content`: `Buffer` — the raw file bytes (not JSON-serializable; see note)
+- `contentType`: `string` — the file's MIME type (e.g. `application/pdf`), or `application/octet-stream`
+- `statusCode`: `number` — HTTP status of the download response
+- `headers`: `Record<string, string>` — the response headers
+- `fileName`: `string | null` — filename from `Content-Disposition` (RFC 5987 `filename*` aware), or `null`
+
+> **Note:** `content` holds raw bytes and is not JSON-serializable. If you forward tool results to an LLM (or anything that re-serializes to JSON), handle or strip the `content` key — for example, base64-encode it on the LLM-facing path.
+
 ### Feedback Collection Tool
 
 The StackOne AI SDK includes a built-in feedback collection tool (`tool_feedback`) that allows users to provide feedback on their experience with StackOne tools. This tool is automatically included when using `fetchTools()` and helps improve the SDK based on user input.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 
 export { BaseTool, StackOneTool, Tools } from './tool';
 export { createFeedbackTool } from './feedback';
+export { isBinaryDownloadResult, type BinaryDownloadResult } from './utils/binary-response';
 export { StackOneError } from './utils/error-stackone';
 export { StackOneAPIError } from './utils/error-stackone-api';
 

--- a/src/requestBuilder.test.ts
+++ b/src/requestBuilder.test.ts
@@ -818,7 +818,7 @@ describe('RequestBuilder - binary file downloads', () => {
 		const result = await builder.execute({ id: 'file-123' });
 
 		expect(result.content).toBeInstanceOf(Buffer);
-		expect((result.content as Buffer).equals(Buffer.from(pdfBytes))).toBe(true);
+		expect((result.content as unknown as Buffer).equals(Buffer.from(pdfBytes))).toBe(true);
 		expect(result.contentType).toBe('application/pdf');
 		expect(result.statusCode).toBe(200);
 		expect(result.fileName).toBe('download.pdf');
@@ -841,7 +841,7 @@ describe('RequestBuilder - binary file downloads', () => {
 		const builder = new RequestBuilder(downloadConfig);
 		const result = await builder.execute({ id: 'blob' });
 
-		expect((result.content as Buffer).equals(Buffer.from(blob))).toBe(true);
+		expect((result.content as unknown as Buffer).equals(Buffer.from(blob))).toBe(true);
 		expect(result.contentType).toBe('application/octet-stream');
 		expect(result.fileName).toBeNull();
 	});
@@ -892,7 +892,7 @@ describe('RequestBuilder - binary file downloads', () => {
 		const builder = new RequestBuilder(downloadConfig);
 		const result = await builder.execute({ id: 'no-ct' });
 
-		expect((result.content as Buffer).equals(Buffer.from(blob))).toBe(true);
+		expect((result.content as unknown as Buffer).equals(Buffer.from(blob))).toBe(true);
 		expect(result.contentType).toBe('application/octet-stream');
 		expect(result.fileName).toBeNull();
 	});

--- a/src/requestBuilder.test.ts
+++ b/src/requestBuilder.test.ts
@@ -776,3 +776,124 @@ describe('RequestBuilder - Property-Based Tests', () => {
 		});
 	});
 });
+
+/**
+ * Binary file downloads
+ *
+ * File-download actions (e.g. googledrive_unified_download_file) serve raw binary with
+ * the file's own MIME type and a Content-Disposition header - never JSON. The execute()
+ * path must branch on Content-Type and return the bytes plus metadata instead of forcing
+ * a JSON parse (which throws on binary bodies containing non-UTF8 bytes).
+ */
+describe('RequestBuilder - binary file downloads', () => {
+	const downloadConfig = {
+		kind: 'http',
+		method: 'GET',
+		url: 'https://api.example.com/download/{id}',
+		bodyType: 'json',
+		params: [{ name: 'id', location: ParameterLocation.PATH, type: 'string' }],
+	} satisfies HttpExecuteConfig;
+
+	it('returns raw bytes + metadata for a non-JSON (binary) response', async () => {
+		// Leading bytes of a real PDF; the 0xc4 byte is invalid UTF-8 and is exactly what
+		// makes an unconditional response.json() throw on a binary body.
+		const pdfBytes = new Uint8Array([
+			0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0x25, 0xc4, 0xe5, 0xf2, 0xe5, 0xeb,
+		]);
+		server.use(
+			http.get(
+				'https://api.example.com/download/:id',
+				() =>
+					new HttpResponse(pdfBytes, {
+						status: 200,
+						headers: {
+							'content-type': 'application/pdf',
+							'content-disposition': 'attachment; filename="download.pdf"',
+						},
+					}),
+			),
+		);
+
+		const builder = new RequestBuilder(downloadConfig);
+		const result = await builder.execute({ id: 'file-123' });
+
+		expect(result.content).toBeInstanceOf(Buffer);
+		expect((result.content as Buffer).equals(Buffer.from(pdfBytes))).toBe(true);
+		expect(result.contentType).toBe('application/pdf');
+		expect(result.statusCode).toBe(200);
+		expect(result.fileName).toBe('download.pdf');
+		expect((result.headers as Record<string, string>)['content-type']).toBe('application/pdf');
+	});
+
+	it('returns bytes with fileName null when there is no Content-Disposition', async () => {
+		const blob = new Uint8Array([0x00, 0x01, 0x02, 0xc4, 0xff, 0xfe]);
+		server.use(
+			http.get(
+				'https://api.example.com/download/:id',
+				() =>
+					new HttpResponse(blob, {
+						status: 200,
+						headers: { 'content-type': 'application/octet-stream' },
+					}),
+			),
+		);
+
+		const builder = new RequestBuilder(downloadConfig);
+		const result = await builder.execute({ id: 'blob' });
+
+		expect((result.content as Buffer).equals(Buffer.from(blob))).toBe(true);
+		expect(result.contentType).toBe('application/octet-stream');
+		expect(result.fileName).toBeNull();
+	});
+
+	it('still parses a normal JSON response into an object (no content wrapper)', async () => {
+		server.use(
+			http.get('https://api.example.com/download/:id', () =>
+				HttpResponse.json({ id: '123', ok: true }),
+			),
+		);
+
+		const builder = new RequestBuilder(downloadConfig);
+		const result = await builder.execute({ id: 'json' });
+
+		expect(result).toEqual({ id: '123', ok: true });
+		expect(result.content).toBeUndefined();
+	});
+
+	it('parses JSON when the Content-Type carries a charset parameter', async () => {
+		server.use(
+			http.get(
+				'https://api.example.com/download/:id',
+				() =>
+					new HttpResponse('{"ok":true}', {
+						status: 200,
+						headers: { 'content-type': 'application/json; charset=utf-8' },
+					}),
+			),
+		);
+
+		const builder = new RequestBuilder(downloadConfig);
+		const result = await builder.execute({ id: 'json-charset' });
+
+		expect(result).toEqual({ ok: true });
+	});
+
+	it('treats a response with no Content-Type as opaque bytes, not JSON', async () => {
+		// JPEG magic bytes, no content-type. The SDK trusts Content-Type to choose JSON vs
+		// file, so an absent Content-Type returns raw bytes rather than risking a JSON decode.
+		const blob = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+		server.use(
+			http.get(
+				'https://api.example.com/download/:id',
+				() => new HttpResponse(blob, { status: 200 }),
+			),
+		);
+
+		const builder = new RequestBuilder(downloadConfig);
+		const result = await builder.execute({ id: 'no-ct' });
+
+		expect((result.content as Buffer).equals(Buffer.from(blob))).toBe(true);
+		expect(result.contentType).toBe('application/octet-stream');
+		expect(result.fileName).toBeNull();
+	});
+});

--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -7,6 +7,7 @@ import {
 	type JsonObject,
 	ParameterLocation,
 } from './types';
+import { binaryDownloadFromResponse, isJsonContentType } from './utils/binary-response';
 import { StackOneAPIError } from './utils/error-stackone-api';
 
 interface SerializationOptions {
@@ -312,7 +313,16 @@ export class RequestBuilder {
 	}
 
 	/**
-	 * Execute the request
+	 * Execute the request.
+	 *
+	 * For JSON responses, returns the parsed API response.
+	 *
+	 * For file downloads (any non-JSON Content-Type, e.g. a `*_unified_download_file` action),
+	 * returns a description of the file:
+	 * `{ content: Buffer, contentType: string, statusCode: number, headers: Record<string, string>,
+	 * fileName: string | null }`. Note `content` holds the raw bytes and is therefore not
+	 * JSON-serializable - callers that re-serialize tool results (e.g. for an LLM) must handle
+	 * this key.
 	 */
 	async execute(params: JsonObject, options?: ExecuteOptions): Promise<JsonObject> {
 		// Prepare request parameters
@@ -371,7 +381,17 @@ export class RequestBuilder {
 			);
 		}
 
-		// Parse the response
-		return (await response.json()) as JsonObject;
+		// Branch on Content-Type: JSON bodies are parsed as before; any non-JSON body is a file
+		// download (raw binary served with the file's own MIME type and a Content-Disposition
+		// header) and must not be forced through response.json(), which throws on binary content.
+		const contentType = response.headers.get('content-type') ?? '';
+		if (isJsonContentType(contentType)) {
+			return (await response.json()) as JsonObject;
+		}
+
+		// Return the raw bytes plus metadata. `content` is a Buffer, which is not representable in
+		// type-fest's JsonValue and so not JSON-serializable; the double-cast is the documented
+		// escape hatch for returning a non-JSON value from this JsonObject-typed method.
+		return (await binaryDownloadFromResponse(response)) as unknown as JsonObject;
 	}
 }

--- a/src/requestBuilder.ts
+++ b/src/requestBuilder.ts
@@ -320,9 +320,9 @@ export class RequestBuilder {
 	 * For file downloads (any non-JSON Content-Type, e.g. a `*_unified_download_file` action),
 	 * returns a description of the file:
 	 * `{ content: Buffer, contentType: string, statusCode: number, headers: Record<string, string>,
-	 * fileName: string | null }`. Note `content` holds the raw bytes and is therefore not
-	 * JSON-serializable - callers that re-serialize tool results (e.g. for an LLM) must handle
-	 * this key.
+	 * fileName: string | null }`. Note `content` is a raw `Buffer`, not a `JsonValue`: it
+	 * JSON-stringifies to a `{ type: 'Buffer', data: [...] }` byte array, so callers that
+	 * re-serialize tool results (e.g. for an LLM) should strip or transform this key.
 	 */
 	async execute(params: JsonObject, options?: ExecuteOptions): Promise<JsonObject> {
 		// Prepare request parameters
@@ -390,8 +390,8 @@ export class RequestBuilder {
 		}
 
 		// Return the raw bytes plus metadata. `content` is a Buffer, which is not representable in
-		// type-fest's JsonValue and so not JSON-serializable; the double-cast is the documented
-		// escape hatch for returning a non-JSON value from this JsonObject-typed method.
+		// type-fest's JsonValue (and JSON-stringifies to a byte array, not the file); the double-cast
+		// is the documented escape hatch for returning a non-JSON value from this JsonObject method.
 		return (await binaryDownloadFromResponse(response)) as unknown as JsonObject;
 	}
 }

--- a/src/rpc-client.test.ts
+++ b/src/rpc-client.test.ts
@@ -257,4 +257,23 @@ describe('binary file downloads', () => {
 		expect(isBinaryDownloadResult(result)).toBe(false);
 		expect(result).toMatchObject({ data: { ok: true } });
 	});
+
+	it('throws StackOneAPIError (not SyntaxError) for a non-JSON error response', async () => {
+		// A gateway/proxy error often returns a non-JSON body (e.g. HTML). The content-type branch
+		// must not let response.json() throw a raw SyntaxError - surface a StackOneAPIError instead.
+		server.use(
+			http.post(
+				`${TEST_BASE_URL}/actions/rpc`,
+				() =>
+					new HttpResponse('<html><body>502 Bad Gateway</body></html>', {
+						status: 502,
+						headers: { 'content-type': 'text/html' },
+					}),
+			),
+		);
+
+		await expect(
+			newClient().actions.rpcAction({ action: 'googledrive_unified_download_file' }),
+		).rejects.toThrow(StackOneAPIError);
+	});
 });

--- a/src/rpc-client.test.ts
+++ b/src/rpc-client.test.ts
@@ -1,6 +1,9 @@
+import { http, HttpResponse } from 'msw';
 import { TEST_BASE_URL } from '../mocks/constants';
+import { server } from '../mocks/node';
 import { RpcClient } from './rpc-client';
 import { stackOneHeadersSchema } from './headers';
+import { isBinaryDownloadResult } from './utils/binary-response';
 import { StackOneAPIError } from './utils/error-stackone-api';
 
 test('should successfully execute an RPC action', async () => {
@@ -156,4 +159,102 @@ test('should omit defender_config from payload when not provided', async () => {
 	});
 
 	expect((response.data as Record<string, unknown>).received).not.toHaveProperty('defender_config');
+});
+
+/**
+ * Binary file downloads over RPC
+ *
+ * File-download actions (e.g. googledrive_unified_download_file) are served over /actions/rpc
+ * as raw binary with the file's own MIME type and a Content-Disposition header - never the
+ * JSON {data,next} envelope. rpcAction must branch on Content-Type and return the bytes plus
+ * metadata instead of forcing a JSON parse (which throws on binary) or the envelope schema.
+ */
+describe('binary file downloads', () => {
+	const newClient = () =>
+		new RpcClient({ serverURL: TEST_BASE_URL, security: { username: 'test-api-key' } });
+
+	it('returns raw bytes + metadata for a non-JSON (binary) RPC response', async () => {
+		// Leading bytes of a real PDF; the 0xc4 byte is invalid UTF-8 and is exactly what makes
+		// an unconditional response.json() throw on a binary body.
+		const pdfBytes = new Uint8Array([
+			0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0x25, 0xc4, 0xe5, 0xf2, 0xe5, 0xeb,
+		]);
+		server.use(
+			http.post(
+				`${TEST_BASE_URL}/actions/rpc`,
+				() =>
+					new HttpResponse(pdfBytes, {
+						status: 200,
+						headers: {
+							'content-type': 'application/pdf',
+							'content-disposition': 'attachment; filename="download.pdf"',
+						},
+					}),
+			),
+		);
+
+		const result = await newClient().actions.rpcAction({
+			action: 'googledrive_unified_download_file',
+			path: { id: 'file-123' },
+			query: { export_format: 'application/pdf' },
+		});
+
+		expect(isBinaryDownloadResult(result)).toBe(true);
+		if (!isBinaryDownloadResult(result)) throw new Error('expected a binary download result');
+		expect(result.content.equals(Buffer.from(pdfBytes))).toBe(true);
+		expect(result.contentType).toBe('application/pdf');
+		expect(result.statusCode).toBe(200);
+		expect(result.fileName).toBe('download.pdf');
+		expect(result.headers['content-type']).toBe('application/pdf');
+	});
+
+	it('returns bytes with fileName null when there is no Content-Disposition', async () => {
+		const blob = new Uint8Array([0x00, 0x01, 0x02, 0xc4, 0xff, 0xfe]);
+		server.use(
+			http.post(
+				`${TEST_BASE_URL}/actions/rpc`,
+				() =>
+					new HttpResponse(blob, {
+						status: 200,
+						headers: { 'content-type': 'application/octet-stream' },
+					}),
+			),
+		);
+
+		const result = await newClient().actions.rpcAction({ action: 'some_unified_download_file' });
+
+		expect(isBinaryDownloadResult(result)).toBe(true);
+		if (!isBinaryDownloadResult(result)) throw new Error('expected a binary download result');
+		expect(result.content.equals(Buffer.from(blob))).toBe(true);
+		expect(result.contentType).toBe('application/octet-stream');
+		expect(result.fileName).toBeNull();
+	});
+
+	it('still parses a normal JSON envelope (regression)', async () => {
+		const result = await newClient().actions.rpcAction({
+			action: 'bamboohr_get_employee',
+			path: { id: 'emp-123' },
+		});
+
+		expect(isBinaryDownloadResult(result)).toBe(false);
+		expect(result).toHaveProperty('data');
+	});
+
+	it('parses JSON when the Content-Type carries a charset parameter', async () => {
+		server.use(
+			http.post(
+				`${TEST_BASE_URL}/actions/rpc`,
+				() =>
+					new HttpResponse('{"data":{"ok":true}}', {
+						status: 200,
+						headers: { 'content-type': 'application/json; charset=utf-8' },
+					}),
+			),
+		);
+
+		const result = await newClient().actions.rpcAction({ action: 'custom_action' });
+
+		expect(isBinaryDownloadResult(result)).toBe(false);
+		expect(result).toMatchObject({ data: { ok: true } });
+	});
 });

--- a/src/rpc-client.test.ts
+++ b/src/rpc-client.test.ts
@@ -1,10 +1,22 @@
 import { http, HttpResponse } from 'msw';
 import { TEST_BASE_URL } from '../mocks/constants';
 import { server } from '../mocks/node';
-import { RpcClient } from './rpc-client';
+import { type RpcActionResponse, RpcClient } from './rpc-client';
 import { stackOneHeadersSchema } from './headers';
-import { isBinaryDownloadResult } from './utils/binary-response';
+import { type BinaryDownloadResult, isBinaryDownloadResult } from './utils/binary-response';
 import { StackOneAPIError } from './utils/error-stackone-api';
+
+/**
+ * Narrow an rpcAction result to the JSON envelope, failing the test if the call returned a binary
+ * download instead. rpcAction returns `RpcActionResponse | BinaryDownloadResult`, so the JSON-path
+ * assertions below need the non-binary branch to stay type-safe.
+ */
+function expectJsonResponse(result: RpcActionResponse | BinaryDownloadResult): RpcActionResponse {
+	if (isBinaryDownloadResult(result)) {
+		throw new Error('expected a JSON RPC response, received a binary download');
+	}
+	return result;
+}
 
 test('should successfully execute an RPC action', async () => {
 	const client = new RpcClient({
@@ -12,11 +24,13 @@ test('should successfully execute an RPC action', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'bamboohr_get_employee',
-		body: { fields: 'name,email' },
-		path: { id: 'emp-123' },
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'bamboohr_get_employee',
+			body: { fields: 'name,email' },
+			path: { id: 'emp-123' },
+		}),
+	);
 
 	// Response matches server's ActionsRpcResponseApiModel structure
 	expect(response).toHaveProperty('data');
@@ -32,13 +46,15 @@ test('should send correct payload structure', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'custom_action',
-		body: { key: 'value' },
-		headers: stackOneHeadersSchema.parse({ 'x-custom': 'header' }),
-		path: { id: '123' },
-		query: { filter: 'active' },
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'custom_action',
+			body: { key: 'value' },
+			headers: stackOneHeadersSchema.parse({ 'x-custom': 'header' }),
+			path: { id: '123' },
+			query: { filter: 'active' },
+		}),
+	);
 
 	// Response matches server's ActionsRpcResponseApiModel structure
 	expect(response.data).toMatchObject({
@@ -58,9 +74,11 @@ test('should handle list actions with array data', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'bamboohr_list_employees',
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'bamboohr_list_employees',
+		}),
+	);
 
 	// Response data can be an array (matches RpcActionResponseData union type)
 	expect(Array.isArray(response.data)).toBe(true);
@@ -120,10 +138,12 @@ test('should send x-account-id as HTTP header', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'test_account_id_header',
-		headers: stackOneHeadersSchema.parse({ 'x-account-id': 'test-account-123' }),
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'test_account_id_header',
+			headers: stackOneHeadersSchema.parse({ 'x-account-id': 'test-account-123' }),
+		}),
+	);
 
 	// Verify x-account-id is sent both as HTTP header and in request body
 	expect(response.data).toMatchObject({
@@ -138,10 +158,12 @@ test('should forward defender_config in request payload', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'custom_action',
-		defender_config: { enabled: true, block_high_risk: false },
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'custom_action',
+			defender_config: { enabled: true, block_high_risk: false },
+		}),
+	);
 
 	expect(response.data).toMatchObject({
 		received: { defender_config: { enabled: true, block_high_risk: false } },
@@ -154,9 +176,11 @@ test('should omit defender_config from payload when not provided', async () => {
 		security: { username: 'test-api-key' },
 	});
 
-	const response = await client.actions.rpcAction({
-		action: 'custom_action',
-	});
+	const response = expectJsonResponse(
+		await client.actions.rpcAction({
+			action: 'custom_action',
+		}),
+	);
 
 	expect((response.data as Record<string, unknown>).received).not.toHaveProperty('defender_config');
 });

--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -8,6 +8,11 @@ import {
 	rpcActionResponseSchema,
 	rpcClientConfigSchema,
 } from './schema';
+import {
+	type BinaryDownloadResult,
+	binaryDownloadFromResponse,
+	isJsonContentType,
+} from './utils/binary-response';
 import { StackOneAPIError } from './utils/error-stackone-api';
 
 // Re-export types for consumers and to make types portable
@@ -38,14 +43,18 @@ export class RpcClient {
 	 * Actions namespace containing RPC methods
 	 */
 	readonly actions: {
-		rpcAction: (request: RpcActionRequest) => Promise<RpcActionResponse>;
+		rpcAction: (request: RpcActionRequest) => Promise<RpcActionResponse | BinaryDownloadResult>;
 	} = {
 		/**
 		 * Execute an RPC action
 		 * @param request The RPC action request
-		 * @returns The RPC action response matching server's ActionsRpcResponseApiModel
+		 * @returns The RPC action response matching server's ActionsRpcResponseApiModel, or - for a
+		 *   file-download action served as raw binary - a {@link BinaryDownloadResult} of bytes +
+		 *   metadata. `content` holds the raw bytes and is not JSON-serializable.
 		 */
-		rpcAction: async (request: RpcActionRequest): Promise<RpcActionResponse> => {
+		rpcAction: async (
+			request: RpcActionRequest,
+		): Promise<RpcActionResponse | BinaryDownloadResult> => {
 			const validatedRequest = rpcActionRequestSchema.parse(request);
 			const url = `${this.baseUrl}/actions/rpc`;
 
@@ -90,6 +99,16 @@ export class RpcClient {
 					body: JSON.stringify(requestBody),
 					signal: controller.signal,
 				});
+
+				// A successful non-JSON body is a file download (raw binary served with the file's own
+				// MIME type and a Content-Disposition header) - e.g. a *_unified_download_file action.
+				// Return the bytes plus metadata rather than forcing response.json() (which throws on
+				// binary) or the {data,next} envelope schema below. Error responses keep the JSON path.
+				const contentType = response.headers.get('content-type') ?? '';
+				if (response.ok && !isJsonContentType(contentType)) {
+					return await binaryDownloadFromResponse(response);
+				}
+
 				responseBody = await response.json();
 			} catch (error) {
 				if (error instanceof Error && error.name === 'AbortError') {

--- a/src/rpc-client.ts
+++ b/src/rpc-client.ts
@@ -50,7 +50,7 @@ export class RpcClient {
 		 * @param request The RPC action request
 		 * @returns The RPC action response matching server's ActionsRpcResponseApiModel, or - for a
 		 *   file-download action served as raw binary - a {@link BinaryDownloadResult} of bytes +
-		 *   metadata. `content` holds the raw bytes and is not JSON-serializable.
+		 *   metadata. `content` is a raw `Buffer` (not a `JsonValue`); handle it before re-serializing.
 		 */
 		rpcAction: async (
 			request: RpcActionRequest,
@@ -100,13 +100,24 @@ export class RpcClient {
 					signal: controller.signal,
 				});
 
-				// A successful non-JSON body is a file download (raw binary served with the file's own
-				// MIME type and a Content-Disposition header) - e.g. a *_unified_download_file action.
-				// Return the bytes plus metadata rather than forcing response.json() (which throws on
-				// binary) or the {data,next} envelope schema below. Error responses keep the JSON path.
+				// A non-JSON body is never the {data,next} envelope. A successful one is a file download
+				// (raw binary with the file's own MIME type + Content-Disposition) - e.g. a
+				// *_unified_download_file action - returned as bytes + metadata. A non-JSON error body
+				// (e.g. an HTML gateway error) is surfaced as a StackOneAPIError rather than letting
+				// response.json() throw a raw SyntaxError. JSON bodies fall through to the parse +
+				// envelope-validation path below.
 				const contentType = response.headers.get('content-type') ?? '';
-				if (response.ok && !isJsonContentType(contentType)) {
-					return await binaryDownloadFromResponse(response);
+				if (!isJsonContentType(contentType)) {
+					if (response.ok) {
+						return await binaryDownloadFromResponse(response);
+					}
+					const errorText = await response.text().catch(() => null);
+					throw new StackOneAPIError(
+						`RPC action failed for ${url}`,
+						response.status,
+						errorText || null,
+						requestBody,
+					);
 				}
 
 				responseBody = await response.json();

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -25,16 +25,20 @@ import type {
 	ToolParameters,
 } from './types';
 import { DEFAULT_DEFENDER_CONFIG } from './types';
+import type { BinaryDownloadResult } from './utils/binary-response';
 import { StackOneError } from './utils/error-stackone';
 import { StackOneAPIError } from './utils/error-stackone-api';
 import { normalizeActionName } from './utils/normalize';
 
 /**
- * Converts RpcActionResponse to JsonObject in a type-safe manner.
- * RpcActionResponse uses z.passthrough() which preserves additional fields,
- * making it structurally compatible with Record<string, JsonValue>.
+ * Converts an RPC action result to JsonObject in a type-safe manner.
+ *
+ * RpcActionResponse uses z.passthrough() which preserves additional fields, making it
+ * structurally compatible with Record<string, JsonValue>. A BinaryDownloadResult (file
+ * download) is flattened the same way - its `content` Buffer rides through under the value
+ * cast and is not JSON-serializable (callers re-serializing for an LLM must handle it).
  */
-function rpcResponseToJsonObject(response: RpcActionResponse): JsonObject {
+function rpcResponseToJsonObject(response: RpcActionResponse | BinaryDownloadResult): JsonObject {
 	// RpcActionResponse with passthrough() has the shape:
 	// { next?: string | null, data?: ..., [key: string]: unknown }
 	// We extract all properties into a plain object

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -31,12 +31,13 @@ import { StackOneAPIError } from './utils/error-stackone-api';
 import { normalizeActionName } from './utils/normalize';
 
 /**
- * Converts an RPC action result to JsonObject in a type-safe manner.
+ * Converts an RPC action result to a JsonObject by flattening its top-level properties.
  *
  * RpcActionResponse uses z.passthrough() which preserves additional fields, making it
  * structurally compatible with Record<string, JsonValue>. A BinaryDownloadResult (file
  * download) is flattened the same way - its `content` Buffer rides through under the value
- * cast and is not JSON-serializable (callers re-serializing for an LLM must handle it).
+ * cast, so it is not a `JsonValue` (and JSON-stringifies to an unwieldy byte array); callers
+ * re-serializing for an LLM must handle that key.
  */
 function rpcResponseToJsonObject(response: RpcActionResponse | BinaryDownloadResult): JsonObject {
 	// RpcActionResponse with passthrough() has the shape:

--- a/src/utils/binary-response.test.ts
+++ b/src/utils/binary-response.test.ts
@@ -28,6 +28,8 @@ describe('filenameFromContentDisposition', () => {
 		['inline; filename="my report.docx"', 'my report.docx'],
 		// RFC 5987 extended form is percent-decoded and takes precedence over the plain form.
 		['attachment; filename="fallback.txt"; filename*=UTF-8\'\'na%C3%AFve.txt', 'naïve.txt'],
+		// Malformed percent-encoding must not throw - fall back to the raw (undecoded) value.
+		["attachment; filename*=UTF-8''bad%ZZname", 'bad%ZZname'],
 		['attachment', null],
 		[null, null],
 		['', null],

--- a/src/utils/binary-response.test.ts
+++ b/src/utils/binary-response.test.ts
@@ -1,0 +1,37 @@
+import { filenameFromContentDisposition, isJsonContentType } from './binary-response';
+
+/**
+ * Unit tests for the Content-Type and Content-Disposition parsing helpers that drive the
+ * JSON-vs-file decision and filename extraction shared by the HTTP and RPC tool paths.
+ */
+describe('isJsonContentType', () => {
+	it.each([
+		['application/json', true],
+		['application/json; charset=utf-8', true],
+		['APPLICATION/JSON', true],
+		['application/problem+json', true],
+		['application/vnd.api+json', true],
+		['', false],
+		['application/pdf', false],
+		['application/octet-stream', false],
+		['text/plain', false],
+		['text/json-but-not-really', false],
+	])('isJsonContentType(%j) === %s', (input, expected) => {
+		expect(isJsonContentType(input as string)).toBe(expected);
+	});
+});
+
+describe('filenameFromContentDisposition', () => {
+	it.each([
+		['attachment; filename="download.pdf"', 'download.pdf'],
+		['attachment; filename=download.pdf', 'download.pdf'],
+		['inline; filename="my report.docx"', 'my report.docx'],
+		// RFC 5987 extended form is percent-decoded and takes precedence over the plain form.
+		['attachment; filename="fallback.txt"; filename*=UTF-8\'\'na%C3%AFve.txt', 'naïve.txt'],
+		['attachment', null],
+		[null, null],
+		['', null],
+	])('filenameFromContentDisposition(%j) === %j', (input, expected) => {
+		expect(filenameFromContentDisposition(input as string | null)).toBe(expected);
+	});
+});

--- a/src/utils/binary-response.ts
+++ b/src/utils/binary-response.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared handling for binary (file-download) HTTP responses.
+ *
+ * StackOne serves file downloads as raw binary with the file's own MIME type and a
+ * Content-Disposition header - never as the usual JSON envelope. Both the HTTP tool path
+ * (RequestBuilder) and the RPC tool path (RpcClient) must therefore decide JSON-vs-file by
+ * Content-Type and return the bytes plus metadata instead of forcing a JSON parse.
+ */
+
+/**
+ * Result of a non-JSON (file-download) response: the raw bytes plus metadata.
+ *
+ * Note: `content` is a Buffer and is therefore not JSON-serializable. Callers that
+ * re-serialize tool results (e.g. for an LLM) must handle this key.
+ */
+export interface BinaryDownloadResult {
+	content: Buffer;
+	contentType: string;
+	statusCode: number;
+	headers: Record<string, string>;
+	fileName: string | null;
+}
+
+/**
+ * Whether a response body should be parsed as JSON based on its Content-Type.
+ *
+ * Only genuine JSON media types are parsed (`application/json` and structured suffixes such
+ * as `application/problem+json`). Anything else - including a missing Content-Type - is treated
+ * as opaque content (a file download), so the raw bytes are returned instead of being
+ * force-decoded as UTF-8/JSON. This mirrors how the StackOne generated SDKs default unknown
+ * bodies to `application/octet-stream`.
+ */
+export function isJsonContentType(contentType: string): boolean {
+	const mediaType = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+	return mediaType === 'application/json' || mediaType.endsWith('+json');
+}
+
+/**
+ * Extract the filename from a Content-Disposition header value, if present.
+ *
+ * Handles both the plain `filename="example.pdf"` form and the RFC 5987 extended
+ * `filename*=UTF-8''example%20file.pdf` form (which is percent-decoded and takes precedence
+ * when present). Returns null when no filename is present.
+ */
+export function filenameFromContentDisposition(value: string | null): string | null {
+	if (!value) {
+		return null;
+	}
+	const extended = value.match(/filename\*\s*=\s*[^']*'[^']*'([^;]+)/i);
+	if (extended?.[1]) {
+		return decodeURIComponent(extended[1].trim());
+	}
+	const quoted = value.match(/filename\s*=\s*"([^"]*)"/i);
+	if (quoted) {
+		return quoted[1]?.trim() || null;
+	}
+	const bare = value.match(/filename\s*=\s*([^;]+)/i);
+	if (bare?.[1]) {
+		return bare[1].trim().replace(/^"+|"+$/g, '') || null;
+	}
+	return null;
+}
+
+/**
+ * Read a non-JSON `Response` into a {@link BinaryDownloadResult} (bytes + metadata).
+ *
+ * Assumes the caller has already decided the body is non-JSON (see {@link isJsonContentType});
+ * consumes the response body via `arrayBuffer()`.
+ */
+export async function binaryDownloadFromResponse(
+	response: Response,
+): Promise<BinaryDownloadResult> {
+	const contentType = response.headers.get('content-type') ?? '';
+	return {
+		content: Buffer.from(await response.arrayBuffer()),
+		contentType: contentType || 'application/octet-stream',
+		statusCode: response.status,
+		headers: Object.fromEntries(response.headers.entries()),
+		fileName: filenameFromContentDisposition(response.headers.get('content-disposition')),
+	};
+}
+
+/**
+ * Type guard for a {@link BinaryDownloadResult} - true when `content` carries raw bytes.
+ */
+export function isBinaryDownloadResult(value: unknown): value is BinaryDownloadResult {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		Buffer.isBuffer((value as { content?: unknown }).content)
+	);
+}

--- a/src/utils/binary-response.ts
+++ b/src/utils/binary-response.ts
@@ -10,8 +10,9 @@
 /**
  * Result of a non-JSON (file-download) response: the raw bytes plus metadata.
  *
- * Note: `content` is a Buffer and is therefore not JSON-serializable. Callers that
- * re-serialize tool results (e.g. for an LLM) must handle this key.
+ * Note: `content` is a raw `Buffer`, not a `JsonValue`. `JSON.stringify` turns a Buffer into a
+ * `{ type: 'Buffer', data: [...] }` byte array (not the file, and potentially huge), so callers
+ * that re-serialize tool results (e.g. for an LLM) should strip or transform this key.
  */
 export interface BinaryDownloadResult {
 	content: Buffer;
@@ -48,7 +49,14 @@ export function filenameFromContentDisposition(value: string | null): string | n
 	}
 	const extended = value.match(/filename\*\s*=\s*[^']*'[^']*'([^;]+)/i);
 	if (extended?.[1]) {
-		return decodeURIComponent(extended[1].trim());
+		const encoded = extended[1].trim();
+		try {
+			return decodeURIComponent(encoded);
+		} catch {
+			// Malformed percent-encoding: fall back to the raw value rather than throwing and
+			// breaking an otherwise-valid download over a bad Content-Disposition header.
+			return encoded;
+		}
 	}
 	const quoted = value.match(/filename\s*=\s*"([^"]*)"/i);
 	if (quoted) {


### PR DESCRIPTION
## Summary

- File-download actions (e.g. `googledrive_unified_download_file`) serve raw binary with the file's own MIME type and a `Content-Disposition` header. Both execution paths called `response.json()` unconditionally and raised `SyntaxError: Unexpected token '%'` on the first non-JSON byte: `RpcClient.rpcAction` (`src/rpc-client.ts`) and `RequestBuilder.execute` (`src/requestBuilder.ts`). Every `StackOneToolSet` unified action runs through the RPC path, so downloads failed outright.
- Both paths now branch on `Content-Type`: JSON media types (`application/json` and `+json` suffixes) are parsed as before; any other type returns the file as `{ content: Buffer, contentType, statusCode, headers, fileName }`, matching the StackOne generated SDKs' download response shape. `fileName` is parsed from `Content-Disposition` (including RFC 5987 `filename*`).
- Shared logic lives in `src/utils/binary-response.ts`. The public `isBinaryDownloadResult` type guard and `BinaryDownloadResult` type let callers narrow the result without casts.
- Existing JSON responses are unchanged.

Note: `content` holds raw bytes (a `Buffer`) and is not JSON-serializable — callers that re-serialize tool results (e.g. for an LLM) should handle that key. This is the node port of StackOneHQ/stackone-ai-python#190.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tool execution to correctly handle binary file downloads by detecting Content-Type and returning raw bytes plus metadata instead of parsing JSON. This unblocks all `*_unified_download_file` actions over RPC and HTTP (e.g. `googledrive_unified_download_file`).

- **Bug Fixes**
  - Branch on `Content-Type`: parse JSON for `application/json` and `+json`; otherwise return `BinaryDownloadResult` `{ content: Buffer, contentType, statusCode, headers, fileName }`. Non-JSON error bodies now raise `StackOneAPIError` (not `SyntaxError`).
  - Shared helpers in `src/utils/binary-response.ts` (`isJsonContentType`, `isBinaryDownloadResult`, filename parsing incl. RFC 5987 with safe fallback) used by both `RpcClient.actions.rpcAction` and `RequestBuilder.execute`; JSON behavior unchanged.
  - Exported `isBinaryDownloadResult` and `BinaryDownloadResult` from the public API; widened `rpcAction` return type to `RpcActionResponse | BinaryDownloadResult` and updated tests to narrow with the guard; added README docs.
  - Note: `content` is a `Buffer` and not JSON-serializable; encode or omit when forwarding to an LLM.

<sup>Written for commit fd9ebe30a2a03063485d3f93eb9bb8e770bdb9be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-node/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



