### PR TITLE
fix: lazy-load optional ai peer

### DIFF
--- a/src/tool-optional-ai.test.ts
+++ b/src/tool-optional-ai.test.ts
@@ -1,7 +1,12 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { StackOneError } from './utils/error-stackone';
 import { peerDependencies } from '../package.json';
 import { ParameterLocation, type ExecuteConfig, type ToolParameters } from './types';
+
+const builtToolEsm = new URL('../dist/src/tool.mjs', import.meta.url);
+const builtToolCjs = new URL('../dist/src/tool.cjs', import.meta.url);
+const distReady = existsSync(builtToolEsm) && existsSync(builtToolCjs);
 
 const createExecuteConfig = (): ExecuteConfig => ({
 	kind: 'http',
@@ -50,13 +55,17 @@ describe('BaseTool optional ai peer handling', () => {
 		);
 	});
 
-	it('keeps the built module free of a top-level ai import', async () => {
-		const builtToolModule = await readFile(
-			new URL('../dist/src/tool.mjs', import.meta.url),
-			'utf8',
-		);
+	it.skipIf(!distReady)('keeps the built ESM module free of a top-level ai import', async () => {
+		const builtToolModule = await readFile(builtToolEsm, 'utf8');
 
 		expect(builtToolModule).toContain('tryImport("ai"');
 		expect(builtToolModule).not.toMatch(/^\s*import\s+.*['"]ai['"]/m);
+	});
+
+	it.skipIf(!distReady)('keeps the built CJS module free of a top-level ai require', async () => {
+		const builtToolModule = await readFile(builtToolCjs, 'utf8');
+
+		expect(builtToolModule).toContain('tryImport("ai"');
+		expect(builtToolModule).not.toMatch(/require\(["']ai["']\)/);
 	});
 });

--- a/src/tool-optional-ai.test.ts
+++ b/src/tool-optional-ai.test.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'node:fs/promises';
+import { StackOneError } from './utils/error-stackone';
+import { peerDependencies } from '../package.json';
+import { ParameterLocation, type ExecuteConfig, type ToolParameters } from './types';
+
+const createExecuteConfig = (): ExecuteConfig => ({
+	kind: 'http',
+	method: 'GET',
+	url: 'https://api.example.com/test/{id}',
+	bodyType: 'json',
+	params: [
+		{
+			name: 'id',
+			location: ParameterLocation.PATH,
+			type: 'string',
+		},
+	],
+});
+
+const createParameters = (): ToolParameters => ({
+	type: 'object',
+	properties: { id: { type: 'string', description: 'ID parameter' } },
+});
+
+describe('BaseTool optional ai peer handling', () => {
+	afterEach(() => {
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it('rejects toClaudeAgentSdkTool with StackOneError and install hint when ai is unavailable', async () => {
+		vi.doMock('./utils/try-import', () => ({
+			tryImport: vi.fn(async (moduleName: string, installHint: string) => {
+				if (moduleName === 'ai') {
+					throw new StackOneError(
+						`${moduleName} is not installed. Please install it with: ${installHint}`,
+					);
+				}
+
+				throw new Error(`Unexpected module request: ${moduleName}`);
+			}),
+		}));
+
+		const { BaseTool } = await import('./tool');
+		const tool = new BaseTool(
+			'test_tool',
+			'Test tool',
+			createParameters(),
+			createExecuteConfig(),
+		);
+
+		await expect(tool.toClaudeAgentSdkTool()).rejects.toBeInstanceOf(StackOneError);
+		await expect(tool.toClaudeAgentSdkTool()).rejects.toThrow(
+			`ai is not installed. Please install it with: npm install ai (requires ${peerDependencies.ai})`,
+		);
+	});
+
+	it('keeps the built module free of a top-level ai import', async () => {
+		const builtToolModule = await readFile(new URL('../dist/src/tool.mjs', import.meta.url), 'utf8');
+
+		expect(builtToolModule).toContain('tryImport("ai"');
+		expect(builtToolModule).not.toMatch(/^\s*import\s+.*['"]ai['"]/m);
+	});
+});

--- a/src/tool-optional-ai.test.ts
+++ b/src/tool-optional-ai.test.ts
@@ -42,12 +42,7 @@ describe('BaseTool optional ai peer handling', () => {
 		}));
 
 		const { BaseTool } = await import('./tool');
-		const tool = new BaseTool(
-			'test_tool',
-			'Test tool',
-			createParameters(),
-			createExecuteConfig(),
-		);
+		const tool = new BaseTool('test_tool', 'Test tool', createParameters(), createExecuteConfig());
 
 		await expect(tool.toClaudeAgentSdkTool()).rejects.toBeInstanceOf(StackOneError);
 		await expect(tool.toClaudeAgentSdkTool()).rejects.toThrow(
@@ -56,7 +51,10 @@ describe('BaseTool optional ai peer handling', () => {
 	});
 
 	it('keeps the built module free of a top-level ai import', async () => {
-		const builtToolModule = await readFile(new URL('../dist/src/tool.mjs', import.meta.url), 'utf8');
+		const builtToolModule = await readFile(
+			new URL('../dist/src/tool.mjs', import.meta.url),
+			'utf8',
+		);
 
 		expect(builtToolModule).toContain('tryImport("ai"');
 		expect(builtToolModule).not.toMatch(/^\s*import\s+.*['"]ai['"]/m);

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,4 +1,4 @@
-import { type JSONSchema7 as AISDKJSONSchema, jsonSchema } from 'ai';
+import type { JSONSchema7 as AISDKJSONSchema } from 'ai';
 import type { Tool as AnthropicTool } from '@anthropic-ai/sdk/resources';
 import type { McpSdkServerConfigWithInstance } from '@anthropic-ai/claude-agent-sdk';
 import type { ChatCompletionFunctionTool } from 'openai/resources/chat/completions';
@@ -248,7 +248,11 @@ export class BaseTool {
 			args: Record<string, unknown>,
 		) => Promise<{ content: Array<{ type: 'text'; text: string }> }>;
 	}> {
-		const inputSchema = jsonSchema(this.toJsonSchema());
+		const ai = await tryImport<typeof import('ai')>(
+			'ai',
+			`npm install ai (requires ${peerDependencies.ai})`,
+		);
+		const inputSchema = ai.jsonSchema(this.toJsonSchema());
 		const execute = this.execute.bind(this);
 
 		return {


### PR DESCRIPTION
## Summary
- remove the top-level runtime import from the optional `ai` peer
- load `ai` through `tryImport()` only when `toClaudeAgentSdkTool()` needs `jsonSchema`
- keep the existing install hint behavior aligned with `toAISDK()`

Fixes #327.

## Validation
- `pnpm run build`
- clean consumer with packed tarball, `@stackone/ai` + `zod` installed and **no `ai` peer installed`: `import('@stackone/ai')` now prints `import ok function`

I also ran `pnpm exec vitest run src/tool.test.ts`; the 47 runtime tests passed, but the command exits non-zero because the configured Vitest typecheck worker cannot spawn `tsc` in this checkout (`typescript` is not installed as a dev dependency).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load the optional `ai` peer so it’s only imported when `jsonSchema` is needed, preventing runtime errors when `ai` isn’t installed; fixes #327. Adds tests to guard against regressions.

- **Bug Fixes**
  - Removed the top-level runtime import from `ai` (kept type-only `JSONSchema7`).
  - Load `ai` on demand in `toClaudeAgentSdkTool()` via `tryImport()` with an install hint using `peerDependencies.ai`.
  - Added tests to verify the install hint error and ensure the built ESM has no top-level `ai` import and the built CJS has no top-level `require('ai')`.

<sup>Written for commit 17315ea166fb4f08b1d0f29b0eb82c01b22fb742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-node/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

