### PR TITLE
fix: ship dual ESM/CJS output for Node16 consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,19 @@
 		"!src/**/*.test.ts"
 	],
 	"type": "module",
-	"main": "./dist/index.mjs",
+	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.mts",
+	"types": "./dist/index.d.cts",
 	"exports": {
 		".": "./src/index.ts",
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {
 		"exports": {
-			".": "./dist/index.mjs",
+			".": {
+				"require": "./dist/index.cjs",
+				"import": "./dist/index.mjs"
+			},
 			"./package.json": "./package.json"
 		}
 	},

--- a/scripts/package-exports.test.ts
+++ b/scripts/package-exports.test.ts
@@ -127,10 +127,9 @@ describe('published package output', () => {
 					// runs from the repository's pnpm context.
 					await execFileAsync('pnpm', ['exec', 'tsc', '-p', consumerDir], { cwd: rootDir });
 				} catch (error) {
-					const execError = (error ?? {}) as { stdout?: unknown; stderr?: unknown };
+					const execError = (error ?? {}) as { stdout?: string; stderr?: string };
 					const details =
-						`${String(execError.stdout ?? '')}${String(execError.stderr ?? '')}`.trim() ||
-						String(error);
+						`${execError.stdout ?? ''}${execError.stderr ?? ''}`.trim() || String(error);
 					throw new Error(`tsc failed for the Node16 consumer fixture:\n${details}`);
 				}
 			} finally {

--- a/scripts/package-exports.test.ts
+++ b/scripts/package-exports.test.ts
@@ -36,7 +36,7 @@ const CONSUMER_SOURCE = [
  * consumer project inside `tempDir`, returning the consumer directory.
  *
  * Packing goes through `pnpm pack` because it applies the publishConfig
- * overrides (exports/main/types), producing the same package.json a consumer
+ * override for the exports map, producing the same package.json a consumer
  * gets from the registry. Lifecycle scripts are disabled: the prepack script
  * runs a full build, which must not happen inside the test.
  */

--- a/scripts/package-exports.test.ts
+++ b/scripts/package-exports.test.ts
@@ -4,13 +4,13 @@ import { mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import { publishConfig } from '../package.json';
 
 const execFileAsync = promisify(execFile);
 
-const rootDir = path.resolve(import.meta.dirname, '..');
+const rootDir = fileURLToPath(new URL('..', import.meta.url));
 
 // Typed wider than the current package.json shape so that a malformed exports
 // map surfaces as a test failure rather than a compile error in this file.

--- a/scripts/package-exports.test.ts
+++ b/scripts/package-exports.test.ts
@@ -1,0 +1,142 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { publishConfig } from '../package.json';
+
+const execFileAsync = promisify(execFile);
+
+const rootDir = path.resolve(import.meta.dirname, '..');
+
+// Typed wider than the current package.json shape so that a malformed exports
+// map surfaces as a test failure rather than a compile error in this file.
+const rootExport: string | { require?: string; import?: string } = publishConfig.exports['.'];
+const conditions = typeof rootExport === 'string' ? { import: rootExport } : rootExport;
+const cjsEntry = conditions.require ? path.resolve(rootDir, conditions.require) : undefined;
+const esmEntry = conditions.import ? path.resolve(rootDir, conditions.import) : undefined;
+
+const cjsReady = cjsEntry !== undefined && existsSync(cjsEntry);
+const esmReady = esmEntry !== undefined && existsSync(esmEntry);
+
+const PUBLIC_API_SAMPLE = ['StackOneToolSet', 'BaseTool', 'StackOneError'] as const;
+
+const CONSUMER_SOURCE = [
+	"import { StackOneToolSet } from '@stackone/ai';",
+	'',
+	"export const toolset = new StackOneToolSet({ apiKey: 'test' });",
+	'',
+].join('\n');
+
+/**
+ * Packs the project and unpacks it as `node_modules/@stackone/ai` of a minimal
+ * consumer project inside `tempDir`, returning the consumer directory.
+ *
+ * Packing goes through `pnpm pack` because it applies the publishConfig
+ * overrides (exports/main/types), producing the same package.json a consumer
+ * gets from the registry. Lifecycle scripts are disabled: the prepack script
+ * runs a full build, which must not happen inside the test.
+ */
+async function createConsumerFixture(tempDir: string): Promise<string> {
+	await execFileAsync(
+		'pnpm',
+		['--config.ignore-scripts=true', 'pack', '--pack-destination', tempDir],
+		{ cwd: rootDir },
+	);
+	const tarballName = (await readdir(tempDir)).find((file) => file.endsWith('.tgz'));
+	if (!tarballName) {
+		throw new Error('pnpm pack did not produce a tarball');
+	}
+	await execFileAsync('tar', ['-xzf', tarballName], { cwd: tempDir });
+
+	const consumerDir = path.join(tempDir, 'consumer');
+	const scopeDir = path.join(consumerDir, 'node_modules', '@stackone');
+	await mkdir(scopeDir, { recursive: true });
+	await rename(path.join(tempDir, 'package'), path.join(scopeDir, 'ai'));
+
+	await writeFile(
+		path.join(consumerDir, 'package.json'),
+		JSON.stringify({ name: 'consumer', private: true }),
+	);
+	await writeFile(
+		path.join(consumerDir, 'tsconfig.json'),
+		JSON.stringify({
+			compilerOptions: {
+				module: 'node16',
+				moduleResolution: 'node16',
+				strict: true,
+				noEmit: true,
+				skipLibCheck: true,
+			},
+		}),
+	);
+	// The .cts consumer exercises CommonJS resolution and the .mts consumer
+	// exercises ESM resolution under the Node16 tsconfig.
+	await writeFile(path.join(consumerDir, 'consumer.cts'), CONSUMER_SOURCE);
+	await writeFile(path.join(consumerDir, 'consumer.mts'), CONSUMER_SOURCE);
+	return consumerDir;
+}
+
+/**
+ * Verifies the published package is consumable from both CommonJS and ESM,
+ * including TypeScript projects using Node16 module resolution.
+ * Regression coverage for https://github.com/StackOneHQ/stackone-ai-node/issues/350.
+ *
+ * Tests that exercise the build output are skipped when `dist/` is missing
+ * (run `pnpm build` first); CI always builds before testing.
+ */
+describe('published package output', () => {
+	it('declares require and import conditions for the root export', () => {
+		expect(conditions.require, 'publishConfig exports["."] must have a require condition').toMatch(
+			/\.cjs$/,
+		);
+		expect(conditions.import, 'publishConfig exports["."] must have an import condition').toMatch(
+			/\.mjs$/,
+		);
+	});
+
+	it.skipIf(!cjsReady)('exposes the public API from the CJS entry via require()', () => {
+		const requireFromTest = createRequire(import.meta.url);
+		const moduleExports = requireFromTest(String(cjsEntry)) as Record<string, unknown>;
+		for (const exportName of PUBLIC_API_SAMPLE) {
+			expect(moduleExports[exportName], exportName).toBeTypeOf('function');
+		}
+	});
+
+	it.skipIf(!esmReady)('exposes the public API from the ESM entry via import()', async () => {
+		const moduleExports = (await import(pathToFileURL(String(esmEntry)).href)) as Record<
+			string,
+			unknown
+		>;
+		for (const exportName of PUBLIC_API_SAMPLE) {
+			expect(moduleExports[exportName], exportName).toBeTypeOf('function');
+		}
+	});
+
+	it.skipIf(!esmReady)(
+		'type-checks for consumers using Node16 module resolution',
+		async () => {
+			const tempDir = await mkdtemp(path.join(tmpdir(), 'stackone-node16-'));
+			try {
+				const consumerDir = await createConsumerFixture(tempDir);
+				try {
+					// The consumer fixture has no TypeScript install of its own, so tsc
+					// runs from the repository's pnpm context.
+					await execFileAsync('pnpm', ['exec', 'tsc', '-p', consumerDir], { cwd: rootDir });
+				} catch (error) {
+					const execError = (error ?? {}) as { stdout?: unknown; stderr?: unknown };
+					const details =
+						`${String(execError.stdout ?? '')}${String(execError.stderr ?? '')}`.trim() ||
+						String(error);
+					throw new Error(`tsc failed for the Node16 consumer fixture:\n${details}`);
+				}
+			} finally {
+				await rm(tempDir, { recursive: true, force: true });
+			}
+		},
+		60_000,
+	);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		/* Build for a library */
 		"module": "ESNext",
 		"moduleResolution": "bundler",
+		"rootDir": ".",
 		"outDir": "dist",
 		"sourceMap": true,
 		"declaration": true,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
 	entry: ['./src/index.ts'],
 	outDir: 'dist',
-	format: 'esm',
+	format: ['esm', 'cjs'],
 	clean: true,
 	sourcemap: true,
 	treeshake: true,


### PR DESCRIPTION
 - Build with format: ['esm', 'cjs'] so dist/ ships .cjs/.d.cts alongside .mjs/.d.mts; tsdown regenerates publishConfig.exports with matching require/import conditions (declarations resolve via sibling files, correct under Node16 resolution). Fixes the TS1479 error for TypeScript consumers using module/moduleResolution: node16 in CommonJS projects.
- Add a regression test that packs the package as published, installs it into a throwaway Node16 consumer, and type-checks .cts/.mts consumers with tsc — it fails with the exact TS1479 from the issue if ESM-only output ever returns — plus require()/import() smoke tests. No new dependencies.
- Set rootDir in tsconfig.json to fix a pre-existing TS2209 that made pnpm test exit non-zero.

Note: dual-format packages carry the standard dual-package hazard — a process mixing require() and import() of this package gets two class copies, so cross-boundary instanceof checks can fail; discriminate via err.name or statusCode in that situation.


Fixes #350

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship dual ESM/CJS output so Node16 TypeScript consumers can use both import and require. Fixes TS1479 in CommonJS projects and resolves #350.

- **Bug Fixes**
  - Build `dist/` as ESM and CJS via `tsdown`, emitting `.mjs/.d.mts` and `.cjs/.d.cts`; set `"main"` to `./dist/index.cjs`, `"module"` to `./dist/index.mjs`, `"types"` to `./dist/index.d.cts`, and add `publishConfig.exports` with `require`/`import` conditions.
  - Add a regression test that packs with `pnpm --config.ignore-scripts=true pack`, installs into a throwaway Node16 consumer, type-checks `.cts/.mts` with `tsc`, smoke-tests `require()`/`import()`, verifies `publishConfig.exports["."]`, skips build-output checks when `dist/` is missing, and uses `fileURLToPath(new URL(..., import.meta.url))` instead of `import.meta.dirname`.
  - Set `"rootDir"` in `tsconfig.json` to fix a pre-existing TS2209.

- **Migration**
  - If a process mixes `require()` and `import()` of `@stackone/ai`, avoid cross-boundary `instanceof`; prefer discriminators like `err.name` or `statusCode`.

<sup>Written for commit 53beb9ac06849a2ae91e5366b595058c011188a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-node/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

