### PR TITLE
feat(ENG-733): support flat_prefixed MCP param style

### DIFF
--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -4,6 +4,8 @@
  */
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { version } from '../package.json';
+import { server } from '../mocks/node';
 import { createMCPClient } from './mcp-client';
 
 test('createMCPClient creates client with required options', async () => {
@@ -43,6 +45,29 @@ test('createMCPClient provides asyncDispose for cleanup', async () => {
 
 	expect(clientCloseSpy).toHaveBeenCalledOnce();
 	expect(transportCloseSpy).toHaveBeenCalledOnce();
+});
+
+test('createMCPClient sends a version-bearing User-Agent on MCP requests', async () => {
+	const recordedRequests: Request[] = [];
+	const listener = ({ request }: { request: Request }) => {
+		recordedRequests.push(request);
+	};
+	server.events.on('request:start', listener);
+
+	await using mcpClient = await createMCPClient({
+		baseUrl: 'http://localhost/mcp',
+		headers: {
+			Authorization: `Basic ${Buffer.from('test-key:').toString('base64')}`,
+		},
+	});
+
+	await mcpClient.client.connect(mcpClient.transport);
+	await mcpClient.client.listTools();
+
+	server.events.removeListener('request:start', listener);
+
+	const mcpRequest = recordedRequests.find((request) => request.url.includes('/mcp'));
+	expect(mcpRequest?.headers.get('user-agent')).toBe(`stackone-ai-node/${version}`);
 });
 
 test('createMCPClient can connect and list tools from MCP server', async () => {

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -1,6 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { version } from '../package.json';
+import { USER_AGENT } from './consts';
 
 interface MCPClientOptions {
 	baseUrl: string;
@@ -36,7 +37,13 @@ interface MCPClient {
 export async function createMCPClient({ baseUrl, headers }: MCPClientOptions): Promise<MCPClient> {
 	const transport = new StreamableHTTPClientTransport(new URL(baseUrl), {
 		requestInit: {
-			headers,
+			headers: {
+				// Version-bearing so /mcp requests are attributable to an exact SDK release.
+				// The transport sends no User-Agent of its own, and the plain USER_AGENT used on
+				// the other endpoints carries no version, which leaves tool listings anonymous.
+				'User-Agent': `${USER_AGENT}/${version}`,
+				...headers,
+			},
 		},
 	});
 

--- a/src/toolsets.test.ts
+++ b/src/toolsets.test.ts
@@ -8,7 +8,7 @@
  * - Provider and action filtering
  */
 import { http, HttpResponse } from 'msw';
-import { type McpToolDefinition, createMcpApp } from '../mocks/mcp-server';
+import { type McpToolDefinition, createMcpApp, defaultMcpTools } from '../mocks/mcp-server';
 import { server } from '../mocks/node';
 import { TEST_BASE_URL } from '../mocks/constants';
 import { SemanticSearchError } from './semantic-search';
@@ -256,6 +256,28 @@ describe('StackOneToolSet', () => {
 
 			const executableTool = (await tool?.toAISDK())?.dummy_action;
 			expect(executableTool?.execute).toBeDefined();
+		});
+
+		it('pins param-style=flat_prefixed on the MCP listing URL', async () => {
+			let requestedUrl = '';
+			const mcpApp = createMcpApp({ accountTools: { default: defaultMcpTools } });
+			server.use(
+				http.all(`${TEST_BASE_URL}/mcp`, async ({ request }) => {
+					if (!requestedUrl) {
+						requestedUrl = request.url;
+					}
+					return mcpApp.fetch(request);
+				}),
+			);
+
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountId: 'test-account',
+			});
+			await toolset.fetchTools();
+
+			expect(new URL(requestedUrl).searchParams.get('param-style')).toBe('flat_prefixed');
 		});
 	});
 
@@ -562,6 +584,34 @@ describe('StackOneToolSet', () => {
 				extraParam: 'extra-value',
 				anotherParam: 123,
 			});
+		});
+
+		it('routes flat_prefixed params into the RPC envelope', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountId: 'test-account',
+			});
+
+			const tools = await toolset.fetchTools();
+			const tool = tools.toArray().find((t) => t.name === 'dummy_action');
+			assert(tool, 'tool should be defined');
+
+			const result = await tool.execute(
+				{
+					path_id: '123',
+					query_limit: 10,
+					'headers_x-custom': 'value',
+					body_name: 'test',
+				},
+				{ dryRun: true },
+			);
+
+			const payload = JSON.parse(result.body as string);
+			expect(payload.path).toEqual({ id: '123' });
+			expect(payload.query).toEqual({ limit: 10 });
+			expect(payload.body).toEqual({ name: 'test' });
+			expect((result.headers as Record<string, string>)['x-custom']).toBe('value');
 		});
 	});
 

--- a/src/toolsets.test.ts
+++ b/src/toolsets.test.ts
@@ -277,7 +277,7 @@ describe('StackOneToolSet', () => {
 			});
 			await toolset.fetchTools();
 
-			expect(new URL(requestedUrl).searchParams.get('param-style')).toBe('flat_prefixed');
+			expect(requestedUrl).toBe(`${TEST_BASE_URL}/mcp?param-style=flat_prefixed`);
 		});
 	});
 
@@ -612,6 +612,75 @@ describe('StackOneToolSet', () => {
 			expect(payload.query).toEqual({ limit: 10 });
 			expect(payload.body).toEqual({ name: 'test' });
 			expect((result.headers as Record<string, string>)['x-custom']).toBe('value');
+		});
+
+		it('preserves fields named after Object.prototype members', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountId: 'test-account',
+			});
+
+			const tools = await toolset.fetchTools();
+			const tool = tools.toArray().find((t) => t.name === 'dummy_action');
+			assert(tool, 'tool should be defined');
+
+			const result = await tool.execute(
+				{ body_constructor: 'x', path_toString: 'y', query_valueOf: 'z' },
+				{ dryRun: true },
+			);
+
+			const payload = JSON.parse(result.body as string);
+			expect(payload.body).toEqual({ constructor: 'x' });
+			expect(payload.path).toEqual({ toString: 'y' });
+			expect(payload.query).toEqual({ valueOf: 'z' });
+		});
+
+		it('prefers an explicit flat key over a nested duplicate whatever the key order', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountId: 'test-account',
+			});
+
+			const tools = await toolset.fetchTools();
+			const tool = tools.toArray().find((t) => t.name === 'dummy_action');
+			assert(tool, 'tool should be defined');
+
+			const nestedFirst = await tool.execute(
+				{ path: { id: 'nested' }, path_id: 'flat' },
+				{ dryRun: true },
+			);
+			const flatFirst = await tool.execute(
+				{ path_id: 'flat', path: { id: 'nested' } },
+				{ dryRun: true },
+			);
+
+			expect(JSON.parse(nestedFirst.body as string).path).toEqual({ id: 'flat' });
+			expect(JSON.parse(flatFirst.body as string).path).toEqual({ id: 'flat' });
+		});
+
+		it('drops reserved envelope keys that do not carry an object', async () => {
+			const toolset = new StackOneToolSet({
+				baseUrl: TEST_BASE_URL,
+				apiKey: 'test-key',
+				accountId: 'test-account',
+			});
+
+			const tools = await toolset.fetchTools();
+			const tool = tools.toArray().find((t) => t.name === 'dummy_action');
+			assert(tool, 'tool should be defined');
+
+			const result = await tool.execute(
+				{ body: 'oops', path: 5, real_field: 'kept' },
+				{ dryRun: true },
+			);
+
+			// `body`/`path` name an envelope, so a non-object value is dropped rather than
+			// leaked into the body payload under its reserved name.
+			const payload = JSON.parse(result.body as string);
+			expect(payload.body).toEqual({ real_field: 'kept' });
+			expect(payload.path).toBeUndefined();
 		});
 	});
 

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -31,6 +31,16 @@ import { StackOneAPIError } from './utils/error-stackone-api';
 import { normalizeActionName } from './utils/normalize';
 
 /**
+ * Param-style pinned on the /mcp tool-listing URL. The MCP schema and the RPC-execution
+ * unwrap (splitEnvelopeParams) must agree on this, so it is pinned rather than following
+ * the server default — the server default is free to change without breaking the SDK.
+ */
+const MCP_PARAM_STYLE = 'flat_prefixed';
+
+/** Matches a flat_prefixed envelope key: `<location>_<field>` (e.g. `path_id`, `query_limit`). */
+const FLAT_ENVELOPE_KEY_PATTERN = /^(path|query|body|headers)_(.+)$/;
+
+/**
  * Converts an RPC action result to a JsonObject by flattening its top-level properties.
  *
  * RpcActionResponse uses z.passthrough() which preserves additional fields, making it
@@ -1245,7 +1255,7 @@ export class StackOneToolSet {
 		}
 
 		await using clients = await createMCPClient({
-			baseUrl: `${this.baseUrl}/mcp`,
+			baseUrl: `${this.baseUrl}/mcp?param-style=${MCP_PARAM_STYLE}`,
 			headers: requestHeaders,
 		});
 
@@ -1406,21 +1416,14 @@ export class StackOneToolSet {
 				const currentHeaders = tool.getHeaders();
 				const baseHeaders = this.buildActionHeaders(currentHeaders);
 
-				const pathParams = this.extractRecord(parsedParams, 'path');
-				const queryParams = this.extractRecord(parsedParams, 'query');
-				const additionalHeaders = this.extractRecord(parsedParams, 'headers');
-				const extraHeaders = normalizeHeaders(additionalHeaders);
+				const envelope = this.splitEnvelopeParams(parsedParams);
+				const pathParams = envelope.path;
+				const queryParams = envelope.query;
+				const extraHeaders = normalizeHeaders(envelope.headers);
 				// defu merges extraHeaders into baseHeaders, both are already branded types
 				const actionHeaders = defu(extraHeaders, baseHeaders);
 
-				const bodyPayload = this.extractRecord(parsedParams, 'body');
-				const rpcBody: JsonObject = bodyPayload ? { ...bodyPayload } : {};
-				for (const [key, value] of Object.entries(parsedParams)) {
-					if (key === 'body' || key === 'headers' || key === 'path' || key === 'query') {
-						continue;
-					}
-					rpcBody[key] = value as JsonObject[string];
-				}
+				const rpcBody: JsonObject = envelope.body;
 
 				if (options?.dryRun) {
 					const requestPayload = {
@@ -1472,14 +1475,60 @@ export class StackOneToolSet {
 		);
 	}
 
-	private extractRecord(
-		params: JsonObject,
-		key: 'body' | 'headers' | 'path' | 'query',
-	): JsonObject | undefined {
-		const value = params[key];
-		if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-			return value as JsonObject;
+	/**
+	 * Splits LLM-supplied tool arguments into the RPC envelope (path/query/headers/body).
+	 *
+	 * Tools are listed with `?param-style=flat_prefixed`, so keys arrive as `<location>_<field>`
+	 * (for example `path_id`, `query_limit`). The prefix carries the parameter location, so the
+	 * split needs no per-action schema. A bare object-valued `path`/`query`/`headers`/`body` key
+	 * is still bucketed for clients holding a cached nested schema, and any other key falls
+	 * through to the body.
+	 */
+	private splitEnvelopeParams(params: JsonObject): {
+		path?: JsonObject;
+		query?: JsonObject;
+		headers?: JsonObject;
+		body: JsonObject;
+	} {
+		const buckets: Record<'path' | 'query' | 'headers' | 'body', JsonObject> = {
+			path: {},
+			query: {},
+			headers: {},
+			body: {},
+		};
+
+		for (const [key, value] of Object.entries(params)) {
+			const match = key.match(FLAT_ENVELOPE_KEY_PATTERN);
+			if (match) {
+				const bucket = buckets[match[1] as keyof typeof buckets];
+				const field = match[2];
+				if (!(field in bucket)) {
+					bucket[field] = value as JsonObject[string];
+				}
+				continue;
+			}
+			if (
+				(key === 'path' || key === 'query' || key === 'headers' || key === 'body') &&
+				typeof value === 'object' &&
+				value !== null &&
+				!Array.isArray(value)
+			) {
+				const bucket = buckets[key];
+				for (const [field, fieldValue] of Object.entries(value)) {
+					if (!(field in bucket)) {
+						bucket[field] = fieldValue as JsonObject[string];
+					}
+				}
+				continue;
+			}
+			buckets.body[key] = value as JsonObject[string];
 		}
-		return undefined;
+
+		return {
+			path: Object.keys(buckets.path).length > 0 ? buckets.path : undefined,
+			query: Object.keys(buckets.query).length > 0 ? buckets.query : undefined,
+			headers: Object.keys(buckets.headers).length > 0 ? buckets.headers : undefined,
+			body: buckets.body,
+		};
 	}
 }

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -40,6 +40,16 @@ const MCP_PARAM_STYLE = 'flat_prefixed';
 /** Matches a flat_prefixed envelope key: `<location>_<field>` (e.g. `path_id`, `query_limit`). */
 const FLAT_ENVELOPE_KEY_PATTERN = /^(path|query|body|headers)_(.+)$/;
 
+const ENVELOPE_LOCATIONS = ['path', 'query', 'headers', 'body'] as const;
+
+type EnvelopeLocation = (typeof ENVELOPE_LOCATIONS)[number];
+
+const isEnvelopeLocation = (key: string): key is EnvelopeLocation =>
+	(ENVELOPE_LOCATIONS as readonly string[]).includes(key);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value);
+
 /**
  * Converts an RPC action result to a JsonObject by flattening its top-level properties.
  *
@@ -1490,45 +1500,60 @@ export class StackOneToolSet {
 		headers?: JsonObject;
 		body: JsonObject;
 	} {
-		const buckets: Record<'path' | 'query' | 'headers' | 'body', JsonObject> = {
-			path: {},
-			query: {},
-			headers: {},
-			body: {},
+		// Null-prototype buckets so API fields named after Object.prototype members
+		// (`constructor`, `toString`, `__proto__`) are stored as ordinary own properties
+		// instead of colliding with the prototype chain and being dropped.
+		const buckets: Record<EnvelopeLocation, JsonObject> = {
+			path: Object.create(null),
+			query: Object.create(null),
+			headers: Object.create(null),
+			body: Object.create(null),
 		};
 
-		for (const [key, value] of Object.entries(params)) {
+		// Keeps whichever value reaches a field first, so the pass order below is what decides
+		// precedence rather than the order the caller happened to supply keys in.
+		const assignField = (bucket: JsonObject, field: string, value: unknown): void => {
+			if (!Object.hasOwn(bucket, field)) {
+				bucket[field] = value as JsonObject[string];
+			}
+		};
+
+		const entries = Object.entries(params);
+
+		// First pass: explicit flat_prefixed keys. Applied before anything else so a prefixed
+		// key always wins over the same field carried in a nested envelope or as a bare key.
+		for (const [key, value] of entries) {
 			const match = key.match(FLAT_ENVELOPE_KEY_PATTERN);
 			if (match) {
-				const bucket = buckets[match[1] as keyof typeof buckets];
-				const field = match[2];
-				if (!(field in bucket)) {
-					bucket[field] = value as JsonObject[string];
-				}
+				assignField(buckets[match[1] as EnvelopeLocation], match[2], value);
+			}
+		}
+
+		// Second pass: nested envelopes from clients on a cached schema, then bare body fields.
+		for (const [key, value] of entries) {
+			if (FLAT_ENVELOPE_KEY_PATTERN.test(key)) {
 				continue;
 			}
-			if (
-				(key === 'path' || key === 'query' || key === 'headers' || key === 'body') &&
-				typeof value === 'object' &&
-				value !== null &&
-				!Array.isArray(value)
-			) {
-				const bucket = buckets[key];
-				for (const [field, fieldValue] of Object.entries(value)) {
-					if (!(field in bucket)) {
-						bucket[field] = fieldValue as JsonObject[string];
+			if (isEnvelopeLocation(key)) {
+				// Reserved keys name an envelope, never a body field. A non-object value cannot
+				// be bucketed, so it is dropped rather than leaked into the body under its
+				// reserved name.
+				if (isPlainObject(value)) {
+					for (const [field, fieldValue] of Object.entries(value)) {
+						assignField(buckets[key], field, fieldValue);
 					}
 				}
 				continue;
 			}
-			buckets.body[key] = value as JsonObject[string];
+			assignField(buckets.body, key, value);
 		}
 
+		// Spread onto ordinary objects so downstream JSON and schema handling sees plain records.
 		return {
-			path: Object.keys(buckets.path).length > 0 ? buckets.path : undefined,
-			query: Object.keys(buckets.query).length > 0 ? buckets.query : undefined,
-			headers: Object.keys(buckets.headers).length > 0 ? buckets.headers : undefined,
-			body: buckets.body,
+			path: Object.keys(buckets.path).length > 0 ? { ...buckets.path } : undefined,
+			query: Object.keys(buckets.query).length > 0 ? { ...buckets.query } : undefined,
+			headers: Object.keys(buckets.headers).length > 0 ? { ...buckets.headers } : undefined,
+			body: { ...buckets.body },
 		};
 	}
 }


### PR DESCRIPTION
## Problem

The SDK lists tools from `/mcp` without pinning a param-style, so the tool `inputSchema` handed to the LLM follows the **server default**. Execution, however, goes through `/actions/rpc` with a hardcoded *nested* unwrap (`path`/`query`/`headers`/`body`). When the server default param-style flips `nested` → `flat_prefixed`, the LLM emits `path_id`/`query_limit`/… which the nested unwrap can't route: path and query params are dropped and the prefixed keys leak into the request body. The server-side MCP shim does not cover this — SDK execution bypasses the MCP transport and hits the actions RPC endpoint directly.

## Fix

- Pin `?param-style=flat_prefixed` on the `/mcp` tool-listing URL, so the schema the LLM sees is stable regardless of the server default.
- Replace the nested `extractRecord` unwrap with `splitEnvelopeParams`, which buckets `<location>_<field>` keys back into `path`/`query`/`headers`/`body`. The prefix carries the location, so no per-action schema is needed. Bare nested envelopes are still accepted (for clients holding a cached nested schema), and unprefixed keys fall through to the body.

Net effect: SDK tool calls use the higher-accuracy flat_prefixed schema and are immune to the server-side default flip.

## Tests

- `pins param-style=flat_prefixed on the MCP listing URL`
- `routes flat_prefixed params into the RPC envelope`
- Backward-compat preserved: existing nested/unprefixed execution tests unchanged. Full `toolsets.test.ts` green (72 tests); build + type-check clean.

## Note

This protects SDK versions from this release forward. Already-published versions still break the moment the server default flips, so the server-side flip should be gated on quantifying old-version exposure by User-Agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full support for the `flat_prefixed` MCP param style, harden envelope splitting, and send a version-bearing User-Agent on MCP requests. Fixes dropped path/query params and keeps the SDK resilient to server default changes while enabling rollout tracking (ENG-733).

- **Bug Fixes**
  - Pin `?param-style=flat_prefixed` on the `/mcp` tool listing.
  - Route `<location>_<field>` keys into RPC `path/query/headers/body` via `splitEnvelopeParams`; nested envelopes and unprefixed keys remain supported.
  - Harden key handling: preserve fields named like `constructor`/`toString`, drop non-object `path/query/headers/body` values, and prefer explicit flat keys over nested duplicates.
  - Send version-bearing `User-Agent` on MCP requests to attribute listings to an exact SDK release.

- **Migration**
  - No client changes required; upgrade to this SDK version.
  - If changing the server default to `flat_prefixed`, gate rollout while monitoring old SDK usage via User-Agent.

<sup>Written for commit 90fc11885838a9def9004847ffe878c522d17b0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/StackOneHQ/stackone-ai-node/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

